### PR TITLE
fix: resolve type errors and refine styling

### DIFF
--- a/src/components/BloodTypePicker.native.tsx
+++ b/src/components/BloodTypePicker.native.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
 import { View, StyleSheet } from 'react-native';
-const { Picker } = require('@react-native-picker/picker');
+import { Picker } from '@react-native-picker/picker';
 
-export default function BloodTypePicker({ value, onChange }) {
+type Props = {
+  value: string;
+  onChange: (itemValue: string, itemIndex: number) => void;
+};
+
+export default function BloodTypePicker({ value, onChange }: Props) {
   return (
     <View style={styles.pickerWrapper}>
       <Picker

--- a/src/screens/UserProfile.tsx
+++ b/src/screens/UserProfile.tsx
@@ -447,7 +447,7 @@ export default function UserProfile({ navigation, onLogout }: UserProfileProps) 
               <Text style={modalStyles.label}>Blood Type</Text>
               <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 8 }}>
                 <select
-                  style={{ flex: 1, height: 40, borderColor: editErrors.blood_type ? '#EF4444' : '#E5E7EB', borderWidth: 1, borderRadius: 8, paddingHorizontal: 12, backgroundColor: '#F9FAFB', fontSize: 16 }}
+                  style={{ flex: 1, height: 40, borderColor: editErrors.blood_type ? '#EF4444' : '#E5E7EB', borderWidth: 1, borderRadius: 8, paddingLeft: 12, paddingRight: 12, backgroundColor: '#F9FAFB', fontSize: 16 }}
                   value={edit.blood_type || ''}
                   onChange={e => {
                     setEdit((prev: any) => ({ ...prev, blood_type: e.target.value }));
@@ -479,7 +479,7 @@ export default function UserProfile({ navigation, onLogout }: UserProfileProps) 
               <Text style={modalStyles.label}>Allergies</Text>
               <View style={modalStyles.chipInputRow}>
                 <select
-                  style={{ flex: 1, height: 40, borderColor: '#E5E7EB', borderWidth: 1, borderRadius: 8, paddingHorizontal: 12, backgroundColor: '#F9FAFB', fontSize: 16 }}
+                  style={{ flex: 1, height: 40, borderColor: '#E5E7EB', borderWidth: 1, borderRadius: 8, paddingLeft: 12, paddingRight: 12, backgroundColor: '#F9FAFB', fontSize: 16 }}
                   value={allergyInput}
                   onChange={e => setAllergyInput(e.target.value)}
                 >
@@ -631,7 +631,7 @@ export default function UserProfile({ navigation, onLogout }: UserProfileProps) 
               <Text style={modalStyles.label}>Medical Conditions</Text>
               <View style={modalStyles.chipInputRow}>
                 <select
-                  style={{ flex: 1, height: 40, borderColor: '#E5E7EB', borderWidth: 1, borderRadius: 8, paddingHorizontal: 12, backgroundColor: '#F9FAFB', fontSize: 16 }}
+                  style={{ flex: 1, height: 40, borderColor: '#E5E7EB', borderWidth: 1, borderRadius: 8, paddingLeft: 12, paddingRight: 12, backgroundColor: '#F9FAFB', fontSize: 16 }}
                   value={conditionInput}
                   onChange={e => setConditionInput(e.target.value)}
                 >

--- a/src/utils/localRecalls.ts
+++ b/src/utils/localRecalls.ts
@@ -4,11 +4,27 @@ import nafdacRecalls from '../data/nafdac_recalls.json';
 import ppbRecalls from '../data/ppb_recalls.json';
 import { RecallNotice } from '../types/recall';
 
+type RawRecall = {
+  source: string;
+  gtin?: string;
+  ndc?: string;
+  id?: string;
+  reason: string;
+};
+
+function normalize(recalls: RawRecall[]): RecallNotice[] {
+  return recalls.map((r) => ({
+    source: r.source,
+    code: r.gtin || r.ndc || r.id || '',
+    reason: r.reason,
+  }));
+}
+
 const allRecalls: RecallNotice[] = [
-  ...emaRecalls,
-  ...sahpraRecalls,
-  ...nafdacRecalls,
-  ...ppbRecalls,
+  ...normalize(emaRecalls as RawRecall[]),
+  ...normalize(sahpraRecalls as RawRecall[]),
+  ...normalize(nafdacRecalls as RawRecall[]),
+  ...normalize(ppbRecalls as RawRecall[]),
 ];
 
 export function findLocalRecall(code: string): RecallNotice | null {


### PR DESCRIPTION
## Summary
- add explicit props typing to BloodTypePicker
- clean up select element styling using paddingLeft/paddingRight
- normalize local recall data to include code field

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68a3ddb4bbf4832bb1aa3601e96a0f2e