### PR TITLE
Polish authentication, scanner, and profile UIs

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,11 +1,67 @@
 import React from 'react';
-import { View, StyleSheet, ViewStyle } from 'react-native';
+import { View, StyleSheet, ViewStyle, StyleProp } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
 import { colors, radius, spacing, shadow } from '../theme';
 
-export default function Card({ children, style }: { children: React.ReactNode; style?: ViewStyle }) {
-  return <View style={[styles.card, style]}>{children}</View>;
+const marginKeys = new Set<keyof ViewStyle>([
+  'margin',
+  'marginTop',
+  'marginBottom',
+  'marginLeft',
+  'marginRight',
+  'marginHorizontal',
+  'marginVertical',
+  'marginStart',
+  'marginEnd',
+]);
+
+const splitStyle = (style?: StyleProp<ViewStyle>) => {
+  if (!style) return { marginStyle: undefined, contentStyle: undefined };
+  const flat = StyleSheet.flatten(style) || {};
+  const marginStyle: ViewStyle = {};
+  const contentStyle: ViewStyle = {};
+  (Object.keys(flat) as (keyof ViewStyle)[]).forEach((key) => {
+    const value = flat[key];
+    if (value === undefined) return;
+    if (marginKeys.has(key)) {
+      // @ts-expect-error - dynamic assignment is safe here
+      marginStyle[key] = value;
+    } else {
+      // @ts-expect-error - dynamic assignment is safe here
+      contentStyle[key] = value;
+    }
+  });
+  return { marginStyle, contentStyle };
+};
+
+export default function Card({ children, style }: { children: React.ReactNode; style?: StyleProp<ViewStyle> }) {
+  const { marginStyle, contentStyle } = splitStyle(style);
+  return (
+    <LinearGradient
+      colors={colors.cardGradient}
+      start={{ x: 0, y: 0 }}
+      end={{ x: 1, y: 1 }}
+      style={[styles.gradient, marginStyle]}
+    >
+      <View style={[styles.card, contentStyle]}>
+        {children}
+      </View>
+    </LinearGradient>
+  );
 }
 
 const styles = StyleSheet.create({
-  card: { backgroundColor: colors.surface, borderRadius: radius.lg, padding: spacing.lg, ...shadow.card },
+  gradient: {
+    borderRadius: radius.lg + 2,
+    padding: 1.5,
+  },
+  card: {
+    backgroundColor: colors.glass,
+    borderRadius: radius.lg,
+    padding: spacing.xl,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: 'rgba(255,255,255,0.6)',
+    overflow: 'hidden',
+    ...shadow.soft,
+  },
 });

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Pressable, Text, ViewStyle } from 'react-native';
-import { colors, spacing, radius, shadow } from '../theme';
+import { Pressable, Text, View, ViewStyle } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { colors, radius, shadow } from '../theme';
 
 type Props = {
   label: string;
@@ -14,22 +15,39 @@ export default function Chip({ label, onPress, selected, style }: Props) {
     <Pressable
       onPress={onPress}
       android_ripple={{ color: colors.primary600 }}
-      style={[
-        {
-          paddingVertical: 10,
-          paddingHorizontal: 14,
-          borderRadius: 999,
-          backgroundColor: selected ? 'rgba(37,99,235,0.12)' : colors.chipBg,
-          borderWidth: 1,
-          borderColor: selected ? colors.primary : 'rgba(2,6,23,0.06)',
-          alignItems: 'center',
-          justifyContent: 'center',
-          ...shadow.soft,
-        },
-        style,
-      ]}
+      style={style}
     >
-      <Text style={{ color: selected ? colors.primary : colors.chipText, fontWeight: '600', fontSize: 13 }}>{label}</Text>
+      <LinearGradient
+        colors={selected ? colors.primaryGradient : colors.subtleGradient}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+        style={{
+          borderRadius: radius.pill,
+          padding: 1,
+          ...shadow.soft,
+        }}
+      >
+        <View
+          style={{
+            backgroundColor: selected ? 'transparent' : colors.glass,
+            borderRadius: radius.pill,
+            paddingVertical: 9,
+            paddingHorizontal: 18,
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <Text
+            style={{
+              color: selected ? '#ffffff' : colors.chipText,
+              fontWeight: '600',
+              fontSize: 13,
+            }}
+          >
+            {label}
+          </Text>
+        </View>
+      </LinearGradient>
     </Pressable>
   );
 }

--- a/src/components/GlobalLoader.tsx
+++ b/src/components/GlobalLoader.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, ActivityIndicator, StyleSheet, Text } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
 import { colors, radius, shadow } from '../theme';
 import { useLoading } from '../hooks/LoadingContext';
 
@@ -8,10 +9,15 @@ export default function GlobalLoader() {
   if (!isLoading) return null;
   return (
     <View style={[styles.overlay]} accessibilityElementsHidden={false} importantForAccessibility="no-hide-descendants">
-      <View style={[styles.container]}>
+      <LinearGradient
+        colors={colors.subtleGradient}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+        style={styles.container}
+      >
         <ActivityIndicator size="large" color={colors.primary} />
         <Text style={styles.text}>Loading…</Text>
-      </View>
+      </LinearGradient>
     </View>
   );
 }

--- a/src/components/ListRow.tsx
+++ b/src/components/ListRow.tsx
@@ -7,7 +7,7 @@ export function ListRow(props: Readonly<{ title: string; subtitle?: string; imag
   const a11yLabel = subtitle ? title + ', ' + subtitle : title;
   return (
     <Pressable onPress={onPress} style={s.row} accessibilityRole={'button' as AccessibilityRole} accessibilityLabel={a11yLabel}>
-      {imageUri ? <Image source={{uri:imageUri}} style={s.avatar}/> : <View style={[s.avatar,{backgroundColor: colors.primary + '22'}]}/>} 
+      {imageUri ? <Image source={{uri:imageUri}} style={s.avatar}/> : <View style={[s.avatar,{backgroundColor: colors.primary + '22'}]}/>}
       <View style={{flex:1}}>
         <Text numberOfLines={1} ellipsizeMode="tail" style={s.title}>{title}</Text>
         {subtitle ? <Text numberOfLines={2} ellipsizeMode="tail" style={s.sub}>{subtitle}</Text> : null}
@@ -18,8 +18,16 @@ export function ListRow(props: Readonly<{ title: string; subtitle?: string; imag
 }
 
 const s = StyleSheet.create({
-  row: { flexDirection: 'row', alignItems: 'center', paddingVertical: spacing.sm, gap: 12 },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.sm,
+    gap: 12,
+    borderRadius: radius.lg,
+    backgroundColor: 'rgba(255,255,255,0.65)',
+  },
   avatar: { width: 48, height: 48, borderRadius: radius.pill, marginRight: spacing.sm },
   title: { ...type.body, fontSize: 16, fontWeight: '700', color: colors.text },
-  sub: { fontSize: 13, color: colors.muted, marginTop: 2 },
+  sub: { fontSize: 13, color: colors.muted, marginTop: 4 },
 });

--- a/src/components/Pill.tsx
+++ b/src/components/Pill.tsx
@@ -1,8 +1,35 @@
 import { View, Text, StyleSheet } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
 import { colors, radius } from '../theme';
-export function Pill({ children, tone='primary' }:{children:string; tone?:'primary'|'warn'|'neutral'}) {
-  const map = { primary:[ '#E8F0FF', colors.primary ], warn:[ '#FFF7E6', colors.warn ], neutral:[ '#EEF2F7', colors.muted ] } as any;
-  const [bg, fg] = map[tone];
-  return <View style={[styles.pill,{backgroundColor:bg}]}><Text style={[styles.txt,{color:fg}]}>{children}</Text></View>;
+
+const toneMap = {
+  primary: colors.primaryGradient,
+  warn: ['#FCD34D', '#F59E0B'] as const,
+  neutral: ['#CBD5F5', '#94A3B8'] as const,
+};
+
+export function Pill({ children, tone = 'primary' }: { children: string; tone?: 'primary' | 'warn' | 'neutral' }) {
+  const gradient = toneMap[tone] ?? colors.primaryGradient;
+  return (
+    <LinearGradient colors={gradient} start={{ x: 0, y: 0 }} end={{ x: 1, y: 1 }} style={styles.wrap}>
+      <View style={styles.pill}>
+        <Text style={styles.txt}>{children}</Text>
+      </View>
+    </LinearGradient>
+  );
 }
-const styles = StyleSheet.create({ pill:{ borderRadius:999, paddingHorizontal:12, paddingVertical:6 }, txt:{ fontSize:12, fontWeight:'700' } });
+
+const styles = StyleSheet.create({
+  wrap: {
+    borderRadius: radius.pill,
+    paddingHorizontal: 1,
+    paddingVertical: 1,
+  },
+  pill: {
+    borderRadius: radius.pill,
+    paddingHorizontal: 14,
+    paddingVertical: 6,
+    backgroundColor: 'rgba(255,255,255,0.85)',
+  },
+  txt: { fontSize: 12, fontWeight: '700', color: colors.text },
+});

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, ViewStyle } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
 import { colors } from '../theme';
 
 type Props = {
@@ -23,13 +24,14 @@ export default function ProgressBar({ progress, height = 8, style }: Props) {
         style,
       ]}
     >
-      <View
-        style={{
-          width: `${pct * 100}%`,
-          height: '100%',
-          backgroundColor: colors.progressFill,
-        }}
-      />
+      <View style={{ width: `${pct * 100}%`, height: '100%' }}>
+        <LinearGradient
+          colors={colors.primaryGradient}
+          start={{ x: 0, y: 0 }}
+          end={{ x: 1, y: 0 }}
+          style={{ flex: 1 }}
+        />
+      </View>
     </View>
   );
 }

--- a/src/components/ScreenContainer.tsx
+++ b/src/components/ScreenContainer.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { ScrollView, View, ViewStyle } from 'react-native';
+import { SafeAreaView, type Edges } from 'react-native-safe-area-context';
+import { LinearGradient } from 'expo-linear-gradient';
+import { colors, spacing } from '../theme';
+
+type ScreenContainerProps = {
+  children: React.ReactNode;
+  /** Set true to wrap children in a ScrollView */
+  scrollable?: boolean;
+  /** Optional padding override for the inner content */
+  contentContainerStyle?: ViewStyle | ViewStyle[];
+  /** Style applied to the non-scrollable container */
+  style?: ViewStyle | ViewStyle[];
+  /** Safe-area edges to include. Defaults to top/left/right */
+  edges?: Edges;
+  /** Whether to add default horizontal padding */
+  withPadding?: boolean;
+  /** Optional component rendered above the content (e.g. hero headers) */
+  header?: React.ReactNode;
+};
+
+const basePadding: ViewStyle = {
+  paddingHorizontal: spacing.xl,
+  paddingTop: spacing.xl,
+  paddingBottom: spacing.xl,
+};
+
+export default function ScreenContainer({
+  children,
+  scrollable,
+  contentContainerStyle,
+  style,
+  edges,
+  withPadding = true,
+  header,
+}: Readonly<ScreenContainerProps>) {
+  const ContainerComponent = scrollable ? ScrollView : View;
+  const defaultEdges: Edges = edges ?? ['top', 'left', 'right'];
+  const paddingStyle = withPadding ? basePadding : undefined;
+
+  return (
+    <LinearGradient
+      colors={[colors.bg, colors.surface]}
+      start={{ x: 0, y: 0 }}
+      end={{ x: 1, y: 1 }}
+      style={{ flex: 1 }}
+    >
+      <SafeAreaView
+        edges={defaultEdges}
+        style={{ flex: 1 }}
+      >
+        <ContainerComponent
+          {...(scrollable
+            ? {
+                contentContainerStyle: [
+                  paddingStyle,
+                  { paddingBottom: spacing.xxl + 12 },
+                  contentContainerStyle,
+                ] as ViewStyle[],
+                showsVerticalScrollIndicator: false,
+                keyboardShouldPersistTaps: 'handled' as const,
+              }
+            : {
+                style: [
+                  { flex: 1 },
+                  paddingStyle,
+                  style,
+                ] as ViewStyle[],
+              })}
+        >
+          {header}
+          {children}
+        </ContainerComponent>
+      </SafeAreaView>
+    </LinearGradient>
+  );
+}

--- a/src/components/SegmentedControl.tsx
+++ b/src/components/SegmentedControl.tsx
@@ -1,5 +1,6 @@
 import { View, Pressable, Text, StyleSheet } from 'react-native';
-import { colors, radius } from '../theme';
+import { LinearGradient } from 'expo-linear-gradient';
+import { colors, radius, shadow } from '../theme';
 export function SegmentedControl({ options, value, onChange }:{
   options:string[]; value:string; onChange:(v:string)=>void;
 }) {
@@ -7,9 +8,18 @@ export function SegmentedControl({ options, value, onChange }:{
     <View style={styles.wrap}>
       {options.map(opt=>{
         const active = opt===value;
+        const content = (
+          <View style={[styles.btn, active && styles.active]}>
+            <Text style={[styles.lbl, active && styles.albl]}>{opt}</Text>
+          </View>
+        );
         return (
-          <Pressable key={opt} onPress={()=>onChange(opt)} style={[styles.btn, active&&styles.active]}>
-            <Text style={[styles.lbl, active&&styles.albl]}>{opt}</Text>
+          <Pressable key={opt} onPress={()=>onChange(opt)} style={styles.pressable}>
+            {active ? (
+              <LinearGradient colors={colors.primaryGradient} start={{x:0,y:0}} end={{x:1,y:1}} style={styles.gradientWrap}>
+                {content}
+              </LinearGradient>
+            ) : content}
           </Pressable>
         );
       })}
@@ -17,9 +27,11 @@ export function SegmentedControl({ options, value, onChange }:{
   );
 }
 const styles = StyleSheet.create({
-  wrap:{ flexDirection:'row', backgroundColor:'#EFF3FF', borderRadius: radius.lg, padding:4, gap:6 },
-  btn:{ flex:1, alignItems:'center', paddingVertical:10, borderRadius: radius.md },
-  active:{ backgroundColor: colors.card },
+  wrap:{ flexDirection:'row', backgroundColor: 'rgba(255,255,255,0.65)', borderRadius: radius.lg, padding:4, gap:6 },
+  pressable:{ flex:1, borderRadius: radius.md, overflow:'hidden' },
+  gradientWrap:{ flex:1, borderRadius: radius.md, padding:1, ...shadow.soft },
+  btn:{ flex:1, alignItems:'center', justifyContent:'center', paddingVertical:10, borderRadius: radius.md, backgroundColor: 'rgba(248,250,255,0.7)' },
+  active:{ backgroundColor: 'rgba(255,255,255,0.2)' },
   lbl:{ color: colors.muted, fontWeight:'600' },
-  albl:{ color: colors.primary },
+  albl:{ color: '#fff' },
 });

--- a/src/screens/BarcodeScanner.tsx
+++ b/src/screens/BarcodeScanner.tsx
@@ -3,10 +3,14 @@ import { saveMedication } from '../utils/myMedications';
 import React, { useState, useEffect, useRef } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { fetchUserProfile, Profile } from '../core/userProfile';
-import { FlatList, View, Text, StyleSheet, ActivityIndicator, TouchableOpacity, ScrollView } from 'react-native';
+import { FlatList, View, Text, StyleSheet, ActivityIndicator, Pressable } from 'react-native';
 import { CameraView, useCameraPermissions } from 'expo-camera';
 import { ensureFocus } from '../utils/cameraHelper';
-import { colors, spacing, shadow } from '../theme';
+import { LinearGradient } from 'expo-linear-gradient';
+import ScreenContainer from '../components/ScreenContainer';
+import Card from '../components/Card';
+import Chip from '../components/Chip';
+import { colors, spacing, shadow, radius } from '../theme';
 import { verifyScannedCode, VerificationResult } from '../utils/verification';
 import { parseGs1DataMatrix } from '../utils/gs1';
 import { normalizeBarcode, parseGs1AIs, validateEAN13CheckDigit, getGtinFromAIs } from '../core/barcode';
@@ -16,109 +20,180 @@ import { summarizeText, safeJoinArrayField } from '../utils/textHelpers';
 import LabelInfoView from '../components/LabelInfoView';
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
+  content: {
+    paddingHorizontal: spacing.xl,
+    paddingBottom: spacing.xxl,
+    gap: spacing.lg,
+  },
+  hero: {
+    paddingTop: spacing.xxl * 1.2,
+    paddingBottom: spacing.xxl,
+    paddingHorizontal: spacing.xl,
+    borderBottomLeftRadius: radius.xl + 6,
+    borderBottomRightRadius: radius.xl + 6,
+    gap: spacing.md,
+  },
+  heroTitle: {
+    fontSize: 28,
+    fontWeight: '700',
+    color: '#fff',
+  },
+  heroSubtitle: {
+    color: 'rgba(255,255,255,0.82)',
+    lineHeight: 20,
+  },
+  heroStats: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+    flexWrap: 'wrap',
+  },
+  statChip: {
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.xs,
+    borderRadius: radius.pill,
+    backgroundColor: 'rgba(255,255,255,0.18)',
+  },
+  statText: {
+    color: '#fff',
+    fontWeight: '600',
+  },
+  scanCard: {
+    gap: spacing.md,
+  },
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: colors.text,
+  },
+  scanInstructions: {
+    color: colors.muted,
+    textAlign: 'center',
+  },
+  cameraShell: {
+    width: '100%',
+    aspectRatio: 1,
+    borderRadius: radius.lg,
+    overflow: 'hidden',
+    backgroundColor: '#000',
+  },
+  overlayFrame: {
+    position: 'absolute',
+    top: '32%',
+    left: '12%',
+    width: '76%',
+    height: '32%',
+    borderRadius: radius.md,
+    borderWidth: 3,
     alignItems: 'center',
     justifyContent: 'center',
-    backgroundColor: colors.bg,
-    padding: spacing.xl,
   },
-  text: {
-    fontSize: 18,
-    color: colors.text,
-    marginBottom: spacing.lg,
-    textAlign: 'center',
-  },
-  scannerBox: {
-    width: 280,
-    height: 280,
-    borderRadius: 18,
-    overflow: 'hidden',
-    borderWidth: 3,
-  borderColor: colors.primary,
-  backgroundColor: '#000',
-    alignSelf: 'center',
-  },
-  resultBox: {
-    alignItems: 'center',
-    backgroundColor: colors.card,
-    borderRadius: 18,
-    padding: spacing.xl,
-  ...shadow.card,
-    minWidth: 260,
-    maxWidth: 340,
-    alignSelf: 'center',
-  },
-  resultTitle: {
-    fontSize: 22,
-    fontWeight: 'bold',
-    color: colors.primary,
-    marginBottom: 12,
-  },
-  resultLabel: {
-    fontSize: 15,
-  color: colors.muted,
-    marginTop: 8,
-    marginBottom: 2,
+  overlayText: {
+    color: '#fff',
     fontWeight: '600',
-    alignSelf: 'flex-start',
   },
-  resultValue: {
-    fontSize: 16,
-    color: colors.text,
-    marginBottom: 4,
-    alignSelf: 'flex-start',
-    // wordBreak: 'break-all', // Not supported in React Native
-  },
-  rescanBtn: {
-    backgroundColor: colors.primary,
-    borderRadius: 8,
-    paddingVertical: 12,
-    paddingHorizontal: 32,
-    marginTop: 18,
-  },
-  error: {
-    color: colors.danger || 'red',
-    fontSize: 16,
-    marginTop: 16,
+  guidance: {
+    color: colors.warn,
     textAlign: 'center',
-    fontWeight: 'bold',
+    fontWeight: '600',
+  },
+  resultCard: {
+    gap: spacing.md,
   },
   userMessage: {
+    color: colors.text,
     fontSize: 16,
-    color: colors.primary,
-    marginTop: 10,
-    marginBottom: 4,
+    lineHeight: 22,
+  },
+  riskCard: {
+    backgroundColor: 'rgba(239,68,68,0.12)',
+    borderRadius: radius.lg,
+    padding: spacing.md,
+    gap: spacing.xs,
+  },
+  riskTitle: {
+    color: colors.danger,
+    fontWeight: '700',
+  },
+  riskText: {
+    color: colors.danger,
+    lineHeight: 20,
+  },
+  positiveText: {
+    color: colors.accent,
+    fontWeight: '600',
+  },
+  negativeText: {
+    color: colors.danger,
+    fontWeight: '600',
+  },
+  analysisCard: {
+    backgroundColor: colors.glass,
+    borderRadius: radius.lg,
+    padding: spacing.md,
+    gap: spacing.sm,
+  },
+  metaText: {
+    color: colors.muted,
+    fontSize: 13,
+  },
+  errorText: {
+    color: colors.danger,
     textAlign: 'center',
     fontWeight: '600',
   },
-  filterBtn: {
-    paddingVertical: 6,
-    paddingHorizontal: 16,
-    borderRadius: 6,
-  backgroundColor: colors.card,
-    marginHorizontal: 4,
+  resultButtons: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+  },
+  secondaryButton: {
+    flex: 1,
     borderWidth: 1,
-    borderColor: colors.muted,
+    borderColor: colors.line,
+    borderRadius: radius.md,
+    paddingVertical: spacing.md,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
-  filterBtnActive: {
+  secondaryText: {
+    color: colors.muted,
+    fontWeight: '600',
+  },
+  primaryButton: {
+    flex: 1,
     backgroundColor: colors.primary,
-    borderColor: colors.primary,
+    borderRadius: radius.md,
+    paddingVertical: spacing.md,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
-  filterBtnText: {
+  primaryText: {
+    color: colors.card,
+    fontWeight: '700',
+  },
+  historyCard: {
+    gap: spacing.md,
+  },
+  historyHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  historyTitle: {
+    fontSize: 18,
+    fontWeight: '700',
     color: colors.text,
-    fontWeight: 'bold',
+  },
+  filterRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.sm,
   },
   historyItem: {
-    backgroundColor: colors.bg,
-    borderRadius: 8,
-    padding: 10,
-    marginBottom: 8,
-    shadowColor: '#000',
-    shadowOpacity: 0.04,
-    shadowRadius: 2,
-    shadowOffset: { width: 0, height: 1 },
-    elevation: 2,
+    backgroundColor: colors.glass,
+    borderRadius: radius.lg,
+    padding: spacing.md,
+    gap: spacing.xs,
+    ...shadow.soft,
   },
   historyType: {
     fontSize: 13,
@@ -126,19 +201,22 @@ const styles = StyleSheet.create({
     fontWeight: '600',
   },
   historyData: {
-    fontSize: 14,
+    fontSize: 15,
     color: colors.text,
-    marginBottom: 2,
   },
   historyMsg: {
     fontSize: 14,
     color: colors.primary,
-    marginBottom: 2,
   },
   historyTime: {
     fontSize: 12,
     color: colors.muted,
     textAlign: 'right',
+  },
+  loader: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
 });
 
@@ -437,11 +515,38 @@ const BarcodeScanner: React.FC = () => {
     };
   }, [scanned, scanData]);
 
+  const heroHeader = (
+    <LinearGradient colors={colors.primaryGradient} start={{ x: 0, y: 0 }} end={{ x: 1, y: 1 }} style={styles.hero}>
+      <Text style={styles.heroTitle}>Medication scanner</Text>
+      <Text style={styles.heroSubtitle}>Verify authenticity and surface risks from your medical ID.</Text>
+      <View style={styles.heroStats}>
+        <View style={styles.statChip}>
+          <Text style={styles.statText}>{history.length} total scans</Text>
+        </View>
+        {(profile?.allergies?.length ?? 0) > 0 ? (
+          <View style={styles.statChip}>
+            <Text style={styles.statText}>{profile?.allergies?.length} allergies monitored</Text>
+          </View>
+        ) : null}
+        {(profile?.medications?.length ?? 0) > 0 ? (
+          <View style={styles.statChip}>
+            <Text style={styles.statText}>{profile?.medications?.length} meds tracked</Text>
+          </View>
+        ) : null}
+      </View>
+    </LinearGradient>
+  );
+
   if (!permission?.granted) {
-    return <View style={styles.container}><ActivityIndicator color={colors.primary} /></View>;
+    return (
+      <ScreenContainer header={heroHeader}>
+        <View style={styles.loader}>
+          <ActivityIndicator color={colors.primary} />
+        </View>
+      </ScreenContainer>
+    );
   }
 
-  // Filter history
   const filteredHistory = history.filter(item => {
     if (filter === 'all') return true;
     if (filter === 'successful') return item.verification && (item.verification.verified || item.verification.recall || item.verification.expired);
@@ -450,198 +555,201 @@ const BarcodeScanner: React.FC = () => {
     return true;
   });
 
-  return (
-    <View style={styles.container}>
-      {!scanned && !scanData && (
-        <>
-          <Text style={styles.text}>Scan any barcode or data matrix on a medication package</Text>
-          <View style={[styles.scannerBox, { justifyContent: 'center', alignItems: 'center' }]}> 
-            <CameraView
-              ref={cameraRef}
-              style={StyleSheet.absoluteFillObject}
-              // expo-camera uses 'autofocus' prop name in some typings; provide a best-effort hint
-              autofocus={'on' as any}
-              onBarcodeScanned={scanned ? undefined : (event: { data: string; type: string }) => {
-                // If barcode is detected but not yet scanned, show detected animation
-                if (!barcodeDetected) setBarcodeDetected(true);
-                handleBarCodeScanned(event);
-              }}
-            />
-            {/* Advanced scan guidance overlay */}
-              <View style={{
-              position: 'absolute',
+  const filterOptions: { label: string; value: typeof filter }[] = [
+    { label: 'All', value: 'all' },
+    { label: 'Successful', value: 'successful' },
+    { label: 'Unsuccessful', value: 'unsuccessful' },
+    { label: 'Risk matched', value: 'risk' },
+  ];
+
+  const renderIdle = () => (
+    <Card style={styles.scanCard}>
+      <Text style={styles.sectionTitle}>Align the barcode inside the frame</Text>
+      <Text style={styles.scanInstructions}>We automatically detect medication barcodes and GS1 data matrix codes.</Text>
+      <View style={styles.cameraShell}>
+        <CameraView
+          ref={cameraRef}
+          style={StyleSheet.absoluteFillObject}
+          autofocus={'on' as any}
+          onBarcodeScanned={scanned ? undefined : (event: { data: string; type: string }) => {
+            if (!barcodeDetected) setBarcodeDetected(true);
+            handleBarCodeScanned(event);
+          }}
+        />
+        <View
+          style={[
+            styles.overlayFrame,
+            {
+              borderColor: showScanEffect ? colors.accent : barcodeDetected ? colors.accent : 'rgba(255,255,255,0.7)',
+              backgroundColor: showScanEffect ? accentRgba(0.12) : barcodeDetected ? accentRgba(0.05) : 'transparent',
+              borderStyle: 'dashed',
               borderWidth: pulse ? 3 : 1,
-              borderColor: showScanEffect ? colors.accent : (barcodeDetected ? colors.accent : colors.card),
-              borderRadius: 14,
-              width: 220,
-              height: 80,
-              top: 100,
-              left: 30,
-              backgroundColor: showScanEffect ? accentRgba(0.08) : (barcodeDetected ? accentRgba(0.04) : 'transparent'),
-              alignItems: 'center',
-              justifyContent: 'center',
-              zIndex: 10,
-              shadowColor: barcodeDetected ? colors.accent : undefined,
-              shadowOpacity: barcodeDetected ? 0.3 : 0,
-              shadowRadius: barcodeDetected ? 8 : 0,
-              shadowOffset: { width: 0, height: 0 },
-            }}>
-              <Text style={{ color: showScanEffect ? colors.accent : (barcodeDetected ? colors.accent : colors.card), fontWeight: 'bold', fontSize: 16 }}>
-                {showScanEffect ? 'Scan Complete!' : barcodeDetected ? 'Barcode Detected!' : 'Align barcode here'}
-              </Text>
-            </View>
+            },
+          ]}
+        >
+          <Text
+            style={[
+              styles.overlayText,
+              { color: showScanEffect ? colors.accent : barcodeDetected ? colors.accent : '#fff' },
+            ]}
+          >
+            {showScanEffect ? 'Scan complete!' : barcodeDetected ? 'Barcode detected' : 'Hold steady'}
+          </Text>
+        </View>
+      </View>
+      {guidance ? <Text style={styles.guidance}>{guidance}</Text> : null}
+    </Card>
+  );
+
+  const renderHistory = history.length > 0 ? (
+    <Card style={styles.historyCard}>
+      <View style={styles.historyHeader}>
+        <Text style={styles.historyTitle}>Recent scans</Text>
+        <Text style={styles.metaText}>{filteredHistory.length} shown</Text>
+      </View>
+      <View style={styles.filterRow}>
+        {filterOptions.map(opt => (
+          <Chip
+            key={opt.value}
+            label={opt.label}
+            selected={filter === opt.value}
+            onPress={() => setFilter(opt.value)}
+          />
+        ))}
+      </View>
+      <FlatList
+        data={filteredHistory}
+        keyExtractor={(item, idx) => `${item.timestamp}_${item.data}_${idx}`}
+        scrollEnabled={false}
+        ItemSeparatorComponent={() => <View style={{ height: spacing.sm }} />}
+        renderItem={({ item }) => (
+          <View style={styles.historyItem}>
+            <Text style={styles.historyType}>{item.type}</Text>
+            <Text style={styles.historyData}>{item.data}</Text>
+            <Text style={styles.historyMsg}>{getUserMessage(item.verification, item.error)}</Text>
+            {item.risk ? <Text style={styles.riskText}>⚠️ {item.risk}</Text> : null}
+            <Text style={styles.historyTime}>{new Date(item.timestamp).toLocaleString()}</Text>
           </View>
-          {guidance && (
-            <Text style={{ color: colors.warn, marginTop: 10, fontWeight: 'bold', textAlign: 'center' }}>{guidance}</Text>
-          )}
-          {history.length > 0 && (
-            <View style={{ marginTop: 32, width: '100%' }}>
-              <Text style={styles.resultTitle}>Scan History</Text>
-              <View style={{ flexDirection: 'row', justifyContent: 'center', marginBottom: 8 }}>
-                <TouchableOpacity onPress={() => setFilter('all')} style={[styles.filterBtn, filter === 'all' && styles.filterBtnActive]}><Text style={styles.filterBtnText}>All</Text></TouchableOpacity>
-                <TouchableOpacity onPress={() => setFilter('successful')} style={[styles.filterBtn, filter === 'successful' && styles.filterBtnActive]}><Text style={styles.filterBtnText}>Successful</Text></TouchableOpacity>
-                <TouchableOpacity onPress={() => setFilter('unsuccessful')} style={[styles.filterBtn, filter === 'unsuccessful' && styles.filterBtnActive]}><Text style={styles.filterBtnText}>Unsuccessful</Text></TouchableOpacity>
-                <TouchableOpacity onPress={() => setFilter('risk')} style={[styles.filterBtn, filter === 'risk' && styles.filterBtnActive]}><Text style={styles.filterBtnText}>Risk Matched</Text></TouchableOpacity>
-              </View>
-              <FlatList
-                data={filteredHistory}
-                keyExtractor={(item, idx) => `${item.timestamp}_${item.data}_${idx}`}
-                renderItem={({ item }) => (
-                  <View style={styles.historyItem}>
-                    <Text style={styles.historyType}>{item.type}</Text>
-                    <Text style={styles.historyData}>{item.data}</Text>
-                    <Text style={styles.historyMsg}>{getUserMessage(item.verification, item.error)}</Text>
-                    {item.risk && item.risk.length > 0 && (
-                      <Text style={{ color: colors.warn, fontSize: 13, marginTop: 2 }}>⚠️ {item.risk}</Text>
-                    )}
-                    <Text style={styles.historyTime}>{new Date(item.timestamp).toLocaleString()}</Text>
+        )}
+      />
+    </Card>
+  ) : null;
+
+  const renderResult = () => (
+    <Card style={styles.resultCard}>
+      <Text style={styles.sectionTitle}>Scan analysis</Text>
+      <Text style={styles.metaText}>Type: {scanData?.type ?? 'Unknown'}</Text>
+      <Text style={styles.metaText}>Raw data: {scanData?.data ?? '—'}</Text>
+      <Text style={styles.userMessage}>{getUserMessage(verification, error)}</Text>
+      {riskWarning ? (
+        <View style={styles.riskCard}>
+          <Text style={styles.riskTitle}>Medication risk</Text>
+          <Text style={styles.riskText}>{riskWarning}</Text>
+        </View>
+      ) : null}
+      {loading ? (
+        <ActivityIndicator color={colors.primary} />
+      ) : (
+        <>
+          {verification ? (
+            <View style={{ gap: spacing.md }}>
+              <View style={styles.analysisCard}>
+                {verification.verified ? <Text style={styles.positiveText}>Authenticity verified</Text> : null}
+                {verification.expired ? <Text style={styles.negativeText}>Expired — do not use</Text> : null}
+                {verification.recall ? (
+                  <View>
+                    <Text style={styles.negativeText}>Recall alert</Text>
+                    <Text style={styles.metaText}>{verification.recall.reason_for_recall}</Text>
+                    <Text style={styles.metaText}>Status: {verification.recall.status}</Text>
                   </View>
-                )}
-                style={{ maxHeight: 220 }}
-              />
+                ) : null}
+                {verification.message ? <Text style={styles.metaText}>{verification.message}</Text> : null}
+              </View>
+              {(verification.labelInfo || verification.label) ? (
+                <LabelInfoView labelInfo={verification.labelInfo} label={verification.label} />
+              ) : null}
+              {(verification.labelInfo || verification.webscraperInfo) ? (
+                <View style={styles.analysisCard}>
+                  {verification.labelInfo ? (
+                    <>
+                      <Text style={styles.sectionTitle}>openFDA insights</Text>
+                      <Text style={styles.metaText}>Indications: {verification.labelInfo.indications || 'N/A'}</Text>
+                      <Text style={styles.metaText}>Dosage: {verification.labelInfo.dosage || 'N/A'}</Text>
+                      <Text style={styles.metaText}>Adverse reactions: {verification.labelInfo.sideEffects || 'N/A'}</Text>
+                    </>
+                  ) : null}
+                  {verification.webscraperInfo ? (
+                    <>
+                      <Text style={styles.sectionTitle}>Supplemental data</Text>
+                      {verification.webscraperInfo.indications ? (
+                        <Text style={styles.metaText}>Indications: {verification.webscraperInfo.indications}</Text>
+                      ) : null}
+                      {verification.webscraperInfo.dosage ? (
+                        <Text style={styles.metaText}>Dosage: {verification.webscraperInfo.dosage}</Text>
+                      ) : null}
+                      {verification.webscraperInfo.sideEffects ? (
+                        <Text style={styles.metaText}>Side effects: {verification.webscraperInfo.sideEffects}</Text>
+                      ) : null}
+                      {!verification.webscraperInfo.indications && !verification.webscraperInfo.dosage && !verification.webscraperInfo.sideEffects ? (
+                        <Text style={styles.metaText}>{JSON.stringify(verification.webscraperInfo, null, 2)}</Text>
+                      ) : null}
+                    </>
+                  ) : null}
+                </View>
+              ) : null}
+              {!verification.verified && !verification.recall && !verification.expired ? (
+                <Text style={styles.metaText}>No authenticity data available. Please exercise caution.</Text>
+              ) : null}
             </View>
-          )}
+          ) : null}
+          {error ? <Text style={styles.errorText}>{error}</Text> : null}
         </>
       )}
-      {scanned && scanData && (
-        <ScrollView contentContainerStyle={styles.resultBox}>
-          <Text style={styles.resultTitle}>Scan Result</Text>
-          <Text style={styles.resultLabel}>Barcode Type:</Text>
-          <Text style={styles.resultValue}>{scanData.type}</Text>
-          <Text style={styles.resultLabel}>Raw Data:</Text>
-          <Text style={styles.resultValue}>{scanData.data}</Text>
-          {loading && <ActivityIndicator color={colors.primary} style={{ marginTop: 12 }} />}
-          <Text style={styles.userMessage}>{getUserMessage(verification, error)}</Text>
-          {riskWarning && (
-            <View style={{ marginTop: 16, alignSelf: 'stretch', backgroundColor: colors.surface, borderColor: colors.warn, borderWidth: 1, borderRadius: 8, padding: 12 }}>
-              <Text style={{ color: colors.warn, fontWeight: 'bold' }}>⚠️ Medication Risk</Text>
-              <Text style={{ color: colors.warn, marginTop: 4 }}>{riskWarning}</Text>
-            </View>
-          )}
-          {verification && (
-            <View style={{ marginTop: 16, alignSelf: 'stretch' }}>
-              {verification.verified && <Text style={{ color: colors.accent }}>Authenticity verified!</Text>}
-              {verification.expired && <Text style={{ color: colors.danger }}>Expired: do not use.</Text>}
-              {verification.recall && (
-                <View>
-                    <Text style={{ color: colors.danger }}>Recall Alert:</Text>
-                  <Text>{verification.recall.reason_for_recall}</Text>
-                  <Text>Status: {verification.recall.status}</Text>
-                </View>
-              )}
-              {(verification.labelInfo || verification.label) && (
-                <LabelInfoView labelInfo={verification.labelInfo} label={verification.label} />
-              )}
-              {/* Show openFDA info if available, else webscraper info, or both if both exist */}
-              {(verification.labelInfo || verification.webscraperInfo) && (
-                <View style={{ marginTop: 12, backgroundColor: colors.line, borderRadius: 8, padding: 10 }}>
-                  {/* openFDA info */}
-                  {verification.labelInfo && (
-                    <>
-                      <Text style={{ fontWeight: 'bold', color: colors.primary }}>Indications & Usage (openFDA)</Text>
-                      <Text style={{ color: colors.text }}>{verification.labelInfo.indications || 'N/A'}</Text>
-                      <Text style={{ fontWeight: 'bold', color: colors.primary, marginTop: 6 }}>Dosage & Administration (openFDA)</Text>
-                      <Text style={{ color: colors.text }}>{verification.labelInfo.dosage || 'N/A'}</Text>
-                      <Text style={{ fontWeight: 'bold', color: colors.primary, marginTop: 6 }}>Adverse Reactions (openFDA)</Text>
-                      <Text style={{ color: colors.text }}>{verification.labelInfo.sideEffects || 'N/A'}</Text>
-                    </>
-                  )}
-                  {/* webscraper info (show if openFDA missing or to supplement) */}
-                  {verification.webscraperInfo && (
-                    <View style={{ marginTop: verification.labelInfo ? 16 : 0 }}>
-                      <Text style={{ fontWeight: 'bold', color: colors.accent }}>Drug Info (Webscraper)</Text>
-                      {verification.webscraperInfo.indications && (
-                        <>
-                          <Text style={{ fontWeight: 'bold', color: colors.primary }}>Indications & Usage</Text>
-                          <Text style={{ color: colors.text }}>{verification.webscraperInfo.indications}</Text>
-                        </>
-                      )}
-                      {verification.webscraperInfo.dosage && (
-                        <>
-                          <Text style={{ fontWeight: 'bold', color: colors.primary, marginTop: 6 }}>Dosage & Administration</Text>
-                          <Text style={{ color: colors.text }}>{verification.webscraperInfo.dosage}</Text>
-                        </>
-                      )}
-                      {verification.webscraperInfo.sideEffects && (
-                        <>
-                          <Text style={{ fontWeight: 'bold', color: colors.primary, marginTop: 6 }}>Adverse Reactions</Text>
-                          <Text style={{ color: colors.text }}>{verification.webscraperInfo.sideEffects}</Text>
-                        </>
-                      )}
-                      {/* Fallback: show all fields if no standard keys */}
-                      {!verification.webscraperInfo.indications && !verification.webscraperInfo.dosage && !verification.webscraperInfo.sideEffects && (
-                        <Text style={{ color: colors.muted }}>No standard drug info fields found from webscraper. Raw data:</Text>
-                      )}
-                      {!verification.webscraperInfo.indications && !verification.webscraperInfo.dosage && !verification.webscraperInfo.sideEffects && (
-                        <Text style={{ color: colors.text, fontSize: 13 }}>{JSON.stringify(verification.webscraperInfo, null, 2)}</Text>
-                      )}
-                    </View>
-                  )}
-                  {/* If neither source yields info, show fallback */}
-                  {!verification.labelInfo && !verification.webscraperInfo && (
-                    <Text style={{ color: colors.muted }}>No drug information found from openFDA or webscraper.</Text>
-                  )}
-                </View>
-              )}
-              {!verification.verified && !verification.recall && !verification.expired && (
-                <Text>No authenticity data available. Exercise caution.</Text>
-              )}
-              <Text style={{ marginTop: 8, color: colors.muted }}>{verification.message}</Text>
-            </View>
-          )}
-          {error && !loading && (
-            <Text style={styles.error}>{error}</Text>
-          )}
-            <TouchableOpacity
-            style={[styles.rescanBtn, { backgroundColor: colors.primary, marginBottom: 10 }]}
-            onPress={() => {
-              setScanned(false); setScanData(null); setVerification(null); setError(null); setLoading(false);
+      <View style={styles.resultButtons}>
+        <Pressable
+          style={styles.secondaryButton}
+          onPress={() => {
+            setScanned(false);
+            setScanData(null);
+            setVerification(null);
+            setError(null);
+            setLoading(false);
+            setRiskWarning(null);
+          }}
+        >
+          <Text style={styles.secondaryText}>Scan again</Text>
+        </Pressable>
+        {verification ? (
+          <Pressable
+            style={styles.primaryButton}
+            onPress={async () => {
+              await saveMedication({
+                code: scanData.data,
+                type: scanData.type,
+                labelInfo: verification.labelInfo,
+                recall: verification.recall,
+                timestamp: Date.now(),
+              });
+              setError('Saved to My Medications!');
+              setTimeout(() => setError(null), 1500);
             }}
           >
-            <Text style={{ color: colors.card, fontWeight: 'bold' }}>Scan Another</Text>
-          </TouchableOpacity>
-          {verification && (
-            <TouchableOpacity
-              style={[styles.rescanBtn, { backgroundColor: colors.accent }]}
-              onPress={async () => {
-                await saveMedication({
-                  code: scanData.data,
-                  type: scanData.type,
-                  labelInfo: verification.labelInfo,
-                  recall: verification.recall,
-                  timestamp: Date.now(),
-                });
-                // Optionally show a confirmation
-                setError('Saved to My Medications!');
-                setTimeout(() => setError(null), 1500);
-              }}
-            >
-              <Text style={{ color: colors.card, fontWeight: 'bold' }}>Save to My Medications</Text>
-            </TouchableOpacity>
-          )}
-        </ScrollView>
-      )}
-    </View>
+            <Text style={styles.primaryText}>Save medication</Text>
+          </Pressable>
+        ) : null}
+      </View>
+    </Card>
+  );
+
+  return (
+    <ScreenContainer
+      scrollable
+      contentContainerStyle={styles.content}
+      header={heroHeader}
+    >
+      {!scanned && !scanData ? renderIdle() : renderResult()}
+      {renderHistory}
+    </ScreenContainer>
   );
 };
 

--- a/src/screens/Clinics.tsx
+++ b/src/screens/Clinics.tsx
@@ -1,9 +1,9 @@
 
 import React, { useState, useMemo, useEffect, useRef } from 'react';
-import { View, ScrollView, Text, TextInput, Platform, Pressable, Modal, Animated, Easing, Dimensions, useWindowDimensions, Image as RNImage } from 'react-native';
+import { View, Text, TextInput, Pressable, Modal, Animated, Easing, Dimensions, useWindowDimensions, Image as RNImage, StyleSheet } from 'react-native';
 import SkeletonImage from '../components/SkeletonImage';
 import type { Facility } from '../types';
-import { colors, spacing, radius } from '../theme';
+import { colors, spacing, radius, shadow } from '../theme';
 import Card from '../components/Card';
 import { ListRow } from '../components/ListRow';
 import { Pill } from '../components/Pill';
@@ -12,6 +12,7 @@ import { useLoading } from '../hooks/LoadingContext';
 import { SegmentedControl } from '../components/SegmentedControl';
 import Chip from '../components/Chip';
 import ClinicsHospitalsPharmaciesMap from './ClinicsHospitalsPharmaciesMap';
+import ScreenContainer from '../components/ScreenContainer';
 
 const FILTERS = ['All', 'Clinic', 'Hospital', 'Pharmacy'];
 
@@ -109,95 +110,35 @@ export default function FacilitiesScreen({ navigation }: any) {
   };
 
   return (
-    <ScrollView style={{ flex: 1, backgroundColor: colors.bg }} contentContainerStyle={{ padding: spacing.xl }}>
-      {/* Search bar */}
-
-      <View style={{ marginBottom: spacing.lg }}>
-    <TextInput
+    <ScreenContainer scrollable contentContainerStyle={styles.content}>
+      <Card style={styles.filterCard}>
+        <TextInput
           placeholder="Search facilities..."
           value={search}
           onChangeText={setSearch}
-          style={{
-      backgroundColor: colors.card,
-      borderRadius: radius.md,
-            paddingHorizontal: 16,
-            paddingVertical: Platform.OS === 'web' ? 12 : 8,
-            fontSize: 16,
-            borderWidth: 1,
-            borderColor: colors.line,
-            marginBottom: 8,
-          }}
+          style={styles.searchInput}
           placeholderTextColor={colors.muted}
         />
         <SegmentedControl options={FILTERS} value={filter} onChange={setFilter} />
-
-        {/* Filter Chips */}
-        <View style={{ flexDirection: 'row', gap: 8, marginTop: 12, flexWrap: 'wrap' }}>
+        <View style={styles.chipRow}>
           <Chip label={openNow ? 'Open Now ✓' : 'Open Now'} selected={openNow} onPress={() => setOpenNow(v => !v)} />
           <Chip label={hasDelivery ? 'Has Delivery ✓' : 'Has Delivery'} selected={hasDelivery} onPress={() => setHasDelivery(v => !v)} />
         </View>
-      </View>
+      </Card>
 
-      {/* Map */}
-      <View style={{ marginBottom: spacing.xl }}>
+      <Card style={styles.mapCard}>
         <ClinicsHospitalsPharmaciesMap filtered={filtered} handleMap={handleMap} />
-      </View>
+      </Card>
 
-      {/* Facility list */}
-      <View style={{ gap: spacing.lg }}>
+      <View style={styles.list}>
         {filtered.map(fac => (
-          <Card key={fac.id} style={{ marginBottom: spacing.lg }}>
+          <Card key={fac.id} style={styles.facilityCard}>
             <ListRow
               title={fac.name}
               subtitle={fac.address || fac.location}
               right={fac.specialty ? <Pill tone="primary">{fac.specialty}</Pill> : undefined}
               onPress={() => openFacilityModal(fac)}
             />
-      {/* Facility Details Modal Sheet */}
-      <Modal
-        visible={modalVisible}
-        animationType="none"
-        transparent
-        onRequestClose={closeFacilityModal}
-      >
-        <View style={{ flex: 1, backgroundColor: colors.overlay, justifyContent: 'flex-end' }}>
-          <Animated.View
-            style={{
-              backgroundColor: colors.card,
-              borderTopLeftRadius: radius.xl,
-              borderTopRightRadius: radius.xl,
-              padding: spacing.xl,
-              paddingBottom: 40,
-              shadowColor: '#000',
-              shadowOpacity: 0.08,
-              shadowRadius: 12,
-              shadowOffset: { width: 0, height: -4 },
-              elevation: 8,
-              transform: [
-                {
-                  translateY: sheetAnim.interpolate({
-                    inputRange: [0, 1],
-                    outputRange: [Dimensions.get('window').height, 0],
-                  }),
-                },
-              ],
-            }}
-          >
-            {selectedFacility && (
-              <>
-                {/* Header */}
-                <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 18 }}>
-                  <Text style={{ fontWeight: 'bold', fontSize: 22, color: colors.text }}>Summary</Text>
-                  <Pressable onPress={closeFacilityModal} hitSlop={10}>
-                    <Text style={{ color: colors.muted, fontWeight: '600', fontSize: 16 }}>Cancel</Text>
-                  </Pressable>
-                </View>
-                {/* Avatar, Name, Specialty */}
-                <View style={{ alignItems: 'center', marginBottom: spacing.lg }}>
-                  {selectedFacility.image ? (
-                    <SkeletonImage source={{ uri: selectedFacility.image }} style={{ width: 64, height: 64, borderRadius: 32, marginBottom: 8 }} resizeMode="cover" />
-                  ) : null}
-                  <Text style={[{ fontSize: 20, fontWeight: '700', color: colors.text, marginTop: spacing.sm }]}>{selectedFacility.name}</Text>
                   <Text style={{ color: colors.muted }}>{selectedFacility.specialty}</Text>
                 </View>
                 {/* Status */}
@@ -253,12 +194,140 @@ export default function FacilitiesScreen({ navigation }: any) {
             </View>
           </Card>
         ))}
-        {loading && <Text style={{ textAlign: 'center' }}>Loading...</Text>}
-        {error && <Text style={{ color: colors.danger }}>{error}</Text>}
-        {filtered.length === 0 && !loading && !error && (
-          <Text style={{ textAlign: 'center', color: colors.muted }}>No facilities found.</Text>
-        )}
       </View>
-    </ScrollView>
+
+      {loading && <Text style={styles.stateText}>Loading...</Text>}
+      {error && <Text style={[styles.stateText, { color: colors.danger }]}>{error}</Text>}
+      {filtered.length === 0 && !loading && !error && (
+        <Text style={styles.stateText}>No facilities found.</Text>
+      )}
+
+      <Modal
+        visible={modalVisible}
+        animationType="none"
+        transparent
+        onRequestClose={closeFacilityModal}
+      >
+        <View style={styles.modalOverlay}>
+          <Animated.View
+            style={[
+              styles.modalSheet,
+              {
+                transform: [
+                  {
+                    translateY: sheetAnim.interpolate({
+                      inputRange: [0, 1],
+                      outputRange: [Dimensions.get('window').height, 0],
+                    }),
+                  },
+                ],
+              },
+            ]}
+          >
+            {selectedFacility && (
+              <>
+                <View style={styles.modalHeader}>
+                  <Text style={styles.modalTitle}>Summary</Text>
+                  <Pressable onPress={closeFacilityModal} hitSlop={10}>
+                    <Text style={styles.modalClose}>Close</Text>
+                  </Pressable>
+                </View>
+                <View style={{ alignItems: 'center', marginBottom: spacing.lg }}>
+                  {selectedFacility.image ? (
+                    <SkeletonImage source={{ uri: selectedFacility.image }} style={styles.modalAvatar} resizeMode="cover" />
+                  ) : null}
+                  <Text style={styles.modalName}>{selectedFacility.name}</Text>
+                  <Text style={styles.modalSubtitle}>{selectedFacility.specialty}</Text>
+                </View>
+                <View style={{ flexDirection: 'row', justifyContent: 'center', gap: 8, marginBottom: spacing.lg }}>
+                  <Pill tone="primary">{selectedFacility.type.charAt(0).toUpperCase() + selectedFacility.type.slice(1)}</Pill>
+                  {selectedFacility.isOpen && <Pill tone="neutral">Open Now</Pill>}
+                  {selectedFacility.hasDelivery && <Pill tone="neutral">Has Delivery</Pill>}
+                </View>
+                <View style={{ gap: 6 }}>
+                  {selectedFacility.address && <Text style={styles.modalDetail}>Address: {selectedFacility.address}</Text>}
+                  {selectedFacility.phoneNumber && <Text style={styles.modalDetail}>Phone: {selectedFacility.phoneNumber}</Text>}
+                  {selectedFacility.hours && <Text style={styles.modalDetail}>Hours: {selectedFacility.hours}</Text>}
+                  {selectedFacility.rating && <Text style={styles.modalDetail}>Rating: {selectedFacility.rating.toFixed(1)}</Text>}
+                  {selectedFacility.services && selectedFacility.services.length > 0 && (
+                    <Text style={styles.modalDetail}>Services: {selectedFacility.services.join(', ')}</Text>
+                  )}
+                  {selectedFacility.languages && selectedFacility.languages.length > 0 && (
+                    <Text style={styles.modalDetail}>Languages: {selectedFacility.languages.join(', ')}</Text>
+                  )}
+                  {selectedFacility.acceptedInsurance && selectedFacility.acceptedInsurance.length > 0 && (
+                    <Text style={styles.modalDetail}>Insurance: {selectedFacility.acceptedInsurance.join(', ')}</Text>
+                  )}
+                </View>
+              </>
+            )}
+          </Animated.View>
+        </View>
+      </Modal>
+    </ScreenContainer>
   );
 }
+
+const styles = StyleSheet.create({
+  content: {
+    gap: spacing.xl,
+    paddingBottom: spacing.xxl,
+  },
+  filterCard: {
+    gap: spacing.md,
+  },
+  searchInput: {
+    backgroundColor: colors.surface,
+    borderRadius: radius.lg,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderWidth: 1,
+    borderColor: colors.line,
+    fontSize: 16,
+  },
+  chipRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 10,
+  },
+  mapCard: {
+    padding: 0,
+    overflow: 'hidden',
+  },
+  list: {
+    gap: spacing.lg,
+  },
+  facilityCard: {
+    gap: spacing.sm,
+  },
+  stateText: {
+    textAlign: 'center',
+    color: colors.muted,
+    marginTop: spacing.md,
+  },
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: colors.overlay,
+    justifyContent: 'flex-end',
+  },
+  modalSheet: {
+    backgroundColor: colors.glass,
+    borderTopLeftRadius: radius.xl,
+    borderTopRightRadius: radius.xl,
+    padding: spacing.xl,
+    paddingBottom: 40,
+    ...shadow.card,
+  },
+  modalHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 18,
+  },
+  modalTitle: { fontWeight: 'bold', fontSize: 22, color: colors.text },
+  modalClose: { color: colors.muted, fontWeight: '600', fontSize: 16 },
+  modalAvatar: { width: 64, height: 64, borderRadius: 32, marginBottom: 8 },
+  modalName: { fontSize: 20, fontWeight: '700', color: colors.text },
+  modalSubtitle: { color: colors.muted, marginTop: 4 },
+  modalDetail: { color: colors.text, fontSize: 15 },
+});

--- a/src/screens/ClinicsHospitalsPharmaciesMap.native.tsx
+++ b/src/screens/ClinicsHospitalsPharmaciesMap.native.tsx
@@ -1,8 +1,9 @@
 
 import React from 'react';
 import MapView, { Marker } from 'react-native-maps';
-import { colors } from '../theme';
-import { View, Dimensions } from 'react-native';
+import { colors, radius } from '../theme';
+import { Dimensions, StyleSheet } from 'react-native';
+import Card from '../components/Card';
 
 interface Facility {
   id: string;
@@ -37,9 +38,9 @@ const ClinicsHospitalsPharmaciesMap: React.FC<Props> = ({ filtered, handleMap })
     : fallbackRegion;
 
   return (
-    <View style={{ flex: 1, width: '100%', height: Dimensions.get('window').height * 0.6 }}>
+    <Card style={styles.card}>
       <MapView
-        style={{ flex: 1 }}
+        style={styles.map}
         initialRegion={region}
       >
         {filtered.map(fac => (
@@ -53,8 +54,20 @@ const ClinicsHospitalsPharmaciesMap: React.FC<Props> = ({ filtered, handleMap })
           />
         ))}
       </MapView>
-    </View>
+    </Card>
   );
 };
 
 export default ClinicsHospitalsPharmaciesMap;
+
+const styles = StyleSheet.create({
+  card: {
+    padding: 0,
+    borderRadius: radius.lg,
+    overflow: 'hidden',
+    height: Dimensions.get('window').height * 0.6,
+  },
+  map: {
+    flex: 1,
+  },
+});

--- a/src/screens/Dashboard.tsx
+++ b/src/screens/Dashboard.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect, useRef } from 'react';
 import { View, Text, Pressable, StyleSheet, Modal, ActivityIndicator, ScrollView, Linking, Platform, Image as RNImage, TextInput } from 'react-native';
 import SkeletonImage from '../components/SkeletonImage';
 import { useLoading } from '../hooks/LoadingContext';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import { fetchUserProfile, type Profile } from '../core/userProfile';
 import { facilities } from '../data';
 import type { Facility } from '../types';
@@ -20,8 +19,9 @@ import NotificationsSheet from '../notifications/NotificationsSheet';
 const AVATAR_PLACEHOLDER = require('../assets/avatar-placeholder.png');
 // Expo’s gradient works on web, iOS, and Android
 import { LinearGradient } from 'expo-linear-gradient';
-// Card import removed (not used in this file)
+import ScreenContainer from '../components/ScreenContainer';
 import MyMedicationsList from '../components/MyMedicationsList';
+import Card from '../components/Card';
 import Chip from '../components/Chip';
 import ProgressBar from '../components/ProgressBar';
 import { Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
@@ -45,10 +45,15 @@ export default function Dashboard({ navigation }: any) {
     const activeReminders = reminders?.filter(r => r.active) ?? [];
     if (activeReminders.length === 0) return <Text style={{ color: colors.muted }}>No reminders found.</Text>;
     return activeReminders.map(rem => (
-      <View key={rem.id} style={{ backgroundColor: colors.line, borderRadius: radius.md, padding: spacing.lg, marginBottom: 10 }}>
-        <Text style={{ fontWeight: '600', color: colors.text }}>{rem.title}</Text>
-        <Text style={{ color: colors.muted, fontSize: 13 }}>{rem.datetime}{rem.frequency ? `  ${rem.frequency}` : ''}</Text>
-        {rem.description && <Text style={{ color: colors.muted, fontSize: 13 }}>{rem.description}</Text>}
+      <View key={rem.id} style={styles.reminderCard}>
+        <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
+          <Text style={styles.reminderTitle}>{rem.title}</Text>
+          <View style={styles.reminderBadge}>
+            <Text style={styles.reminderBadgeText}>{rem.frequency || 'Once'}</Text>
+          </View>
+        </View>
+        <Text style={styles.reminderMeta}>{rem.datetime}</Text>
+        {rem.description ? <Text style={styles.reminderDescription}>{rem.description}</Text> : null}
       </View>
     ));
   };
@@ -105,395 +110,355 @@ export default function Dashboard({ navigation }: any) {
   const progress = pillsDone.total ? pillsDone.done / pillsDone.total : 0;
 
   return (
-    <SafeAreaView style={[styles.container]} edges={['top', 'left', 'right']}>
-      <LinearGradient colors={[colors.bg, colors.surface]} style={styles.flex}>
-        <ScrollView contentContainerStyle={[styles.scrollContent, Platform.OS === 'ios' ? { paddingBottom: 32 } : { paddingBottom: 16 }]}> 
-        <View style={styles.dashboardHeader}>
-          <View style={styles.headerRow}>
-            <Pressable onPress={() => setProfileModal(true)} style={styles.avatarBtn} accessibilityLabel="Open profile" accessibilityRole="button">
-              <SkeletonImage source={AVATAR_PLACEHOLDER} style={styles.avatar} resizeMode="cover" />
-            </Pressable>
-            <NotificationBell onPress={() => setNotificationsVisible(true)} />
-  <NotificationsSheet visible={notificationsVisible} onClose={() => setNotificationsVisible(false)} />
-          </View>
-          <Text style={[type.h1, styles.welcome]}>Welcome{profile?.name ? `, ${profile.name}` : ''}</Text>
-          <Text style={[type.meta, styles.subheading]}>How is it going today?</Text>
-          {/* Search box */}
-          <View style={styles.searchWrap}>
-            <Ionicons name="search" size={18} color={colors.muted} style={{ marginHorizontal: 10 }} />
-            <TextInput
-              placeholder="Search doctors, facilities, meds"
-              placeholderTextColor={colors.muted}
-              style={styles.searchInput}
-              returnKeyType="search"
-            />
-          </View>
-          {/* Category chips */}
-          <View style={styles.chipsRow}>
-            <Chip label="Cardiologist" onPress={() => navigation.navigate('Clinics', { filter: 'cardiologist' })} />
-            <Chip label="Dentist" onPress={() => navigation.navigate('Clinics', { filter: 'dentist' })} />
-            <Chip label="Therapist" onPress={() => navigation.navigate('Clinics', { filter: 'therapist' })} />
-            <Chip label="Geneticist" onPress={() => navigation.navigate('Clinics', { filter: 'geneticist' })} />
-          </View>
-          {/* Today’s progress */}
-          <View style={styles.progressCard}>
-            <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
-              <Text style={{ fontWeight: '700', fontSize: 16, color: colors.text }}>Today's Progress</Text>
-              <Text style={{ color: colors.muted, fontSize: 12 }}>{pillsDone.done}/{pillsDone.total}</Text>
-            </View>
-            <ProgressBar progress={progress} style={{ marginTop: 10 }} />
-          </View>
-          <Pressable
-            onPress={() => setUrgentCareModal(true)}
-            style={styles.cta}
-            android_ripple={{ color: colors.primary600 }}
-            accessibilityRole="button"
-            accessibilityLabel="Open urgent care"
-            accessibilityHint="View nearby urgent care facilities and emergency contacts"
-            hitSlop={8}
-          >
-            <Text style={styles.ctaText}>Urgent Care</Text>
+    <ScreenContainer scrollable contentContainerStyle={styles.content}>
+      <LinearGradient colors={colors.primaryGradient} start={{ x: 0, y: 0 }} end={{ x: 1, y: 1 }} style={styles.heroCard}>
+        <View style={styles.heroTopRow}>
+          <Pressable onPress={() => setProfileModal(true)} style={styles.avatarBtn} accessibilityLabel="Open profile" accessibilityRole="button">
+            <SkeletonImage source={AVATAR_PLACEHOLDER} style={styles.avatar} resizeMode="cover" />
           </Pressable>
-        {/* Urgent Care Modal/Sheet */}
-          <Modal visible={urgentCareModal} animationType="slide" transparent onRequestClose={() => setUrgentCareModal(false)}>
-          <View style={[styles.modalOverlay]}>
-            <View style={styles.facilityModalSheet}>
-              <ScrollView contentContainerStyle={{ paddingBottom: 40 }}>
-                <View style={styles.modalHeaderRow}>
-                  <Text style={styles.modalTitle}>Urgent Care</Text>
-                  <Pressable onPress={() => setUrgentCareModal(false)} hitSlop={10} accessibilityRole="button" accessibilityLabel="Close urgent care sheet">
-                    <Text style={styles.modalCloseText}>Close</Text>
-                  </Pressable>
-                </View>
-                {/* Emergency Contacts */}
-                <Text style={styles.sectionTitle}>Emergency Contacts</Text>
-                <View style={{ marginBottom: spacing.lg }}>
-                  {profile?.emergency_contacts?.length ? (
-                    profile.emergency_contacts.map(contact => (
-                      <View key={contact.phone ?? contact.name} style={styles.contactBlock}>
-                        <Text style={styles.contactName}>{contact.name}</Text>
-                        <Text style={styles.sectionText}>{contact.phone}</Text>
-                        <Text style={styles.sectionText}>{contact.relationship}</Text>
-                        <Pressable onPress={() => Linking.openURL(`tel:${contact.phone}`)} style={{ marginTop: 6 }} accessibilityRole="button">
-                          <Text style={styles.callLink}>Call</Text>
-                        </Pressable>
-                      </View>
-                    ))
-                  ) : (
-                    <Text style={styles.sectionText}>No emergency contacts listed.</Text>
-                  )}
-                </View>
-                {/* Open & Nearby Facilities */}
-                <Text style={styles.sectionTitle}>Open & Nearby Facilities</Text>
-                <View style={{ marginBottom: spacing.lg }}>
-                  {sortByDistance(facilities.filter(f => f.isOpen && (f.type === 'clinic' || f.type === 'hospital' || f.type === 'pharmacy'))).map((fac: Facility) => (
-                    <View key={fac.id} style={styles.facilityItem}>
-                      <Text style={styles.facilityName}>{fac.name} <Text style={styles.facilityMeta}>({fac.type})</Text></Text>
-                      <Text style={styles.sectionText}>{fac.location}</Text>
-                      {'phoneNumber' in fac && fac.phoneNumber && <Text style={styles.sectionText}>Phone: {fac.phoneNumber}</Text>}
-                      <Text style={styles.sectionText}>Distance: {fac.distance || 'N/A'}</Text>
-                      {'phoneNumber' in fac && fac.phoneNumber && (
-                        <Pressable onPress={() => Linking.openURL(`tel:${fac.phoneNumber}`)} style={{ marginTop: 6 }} accessibilityRole="button">
-                          <Text style={styles.callLink}>Call</Text>
-                        </Pressable>
-                      )}
-                    </View>
-                  ))}
-                </View>
-              </ScrollView>
-            </View>
-          </View>
-        </Modal>
-          {/* Removed Xahara logo */}
+          <NotificationBell onPress={() => setNotificationsVisible(true)} />
         </View>
-
-        <View style={styles.servicesCard}>
-          <Text style={{ fontWeight: '700', fontSize: 17, marginBottom: 12, color: colors.text }}>Our Services</Text>
-          <View style={{ flexDirection: 'row', justifyContent: 'space-between', marginBottom: 8 }}>
-            <View style={styles.serviceItem}>
-              <View style={styles.serviceIconWrap}><MaterialCommunityIcons name="barcode-scan" size={22} color={colors.primary} /></View>
-              <Text style={styles.serviceLabel}>Meds Verification</Text>
-            </View>
-            <View style={styles.serviceItem}>
-              <View style={styles.serviceIconWrap}><Ionicons name="medkit" size={20} color={colors.primary} /></View>
-              <Text style={styles.serviceLabel}>Medical ID</Text>
-            </View>
-            <View style={styles.serviceItem}>
-              <View style={styles.serviceIconWrap}><Ionicons name="business" size={20} color={colors.primary} /></View>
-              <Text style={styles.serviceLabel}>Facilities</Text>
-            </View>
-          </View>
+        <Text style={[type.h1, styles.heroTitle]}>Welcome{profile?.name ? `, ${profile.name}` : ''}</Text>
+        <Text style={[type.meta, styles.heroSubtitle]}>How is it going today?</Text>
+        <View style={styles.searchWrap}>
+          <Ionicons name="search" size={18} color={colors.muted} style={{ marginRight: 10 }} />
+          <TextInput
+            placeholder="Search doctors, facilities, meds"
+            placeholderTextColor={colors.muted}
+            style={styles.searchInput}
+            returnKeyType="search"
+          />
         </View>
-
-        <View style={styles.appointmentCard}>
-          <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
-            <Text style={{ fontWeight: '700', fontSize: 17, color: colors.text }}>Reminders</Text>
-          </View>
-          {renderReminders()}
+        <View style={styles.chipsRow}>
+          <Chip label="Cardiologist" onPress={() => navigation.navigate('Clinics', { filter: 'cardiologist' })} />
+          <Chip label="Dentist" onPress={() => navigation.navigate('Clinics', { filter: 'dentist' })} />
+          <Chip label="Therapist" onPress={() => navigation.navigate('Clinics', { filter: 'therapist' })} />
+          <Chip label="Geneticist" onPress={() => navigation.navigate('Clinics', { filter: 'geneticist' })} />
         </View>
-        {/* My Medications Section */}
-        <View style={styles.appointmentCard}>
-          <Text style={{ fontWeight: '700', fontSize: 17, color: colors.text, marginBottom: 8 }}>My Medications</Text>
-          <MyMedicationsList />
-        </View>
-
-        {/* Profile Modal */}
-        <Modal visible={profileModal} animationType="slide" transparent onRequestClose={() => setProfileModal(false)}>
-          <View style={{ flex: 1, backgroundColor: colors.overlay, justifyContent: 'flex-end' }}>
-            <View style={styles.facilityModalSheet}>
-              <ScrollView contentContainerStyle={{ paddingBottom: 40 }}>
-                <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 18 }}>
-                  <Text style={{ fontWeight: 'bold', fontSize: 22, color: colors.text }}>Profile</Text>
-                  <Pressable onPress={() => setProfileModal(false)} hitSlop={10}>
-                    <Text style={{ color: colors.muted, fontWeight: '600', fontSize: 16 }}>Close</Text>
-                  </Pressable>
-                </View>
-                <View style={{ alignItems: 'center', marginBottom: spacing.lg }}>
-                  <SkeletonImage source={AVATAR_PLACEHOLDER} style={styles.profileAvatar} resizeMode="cover" />
-                  {profile ? (
-                    <>
-                      <Text style={{ fontWeight: '700', fontSize: 22, color: colors.text, marginTop: 8 }}>{profile.name}</Text>
-                      <Text style={{ color: colors.muted }}>{profile.email}</Text>
-                      <Text style={{ color: colors.muted }}>{profile.phone}</Text>
-                      <Text style={{ color: colors.muted }}>{profile.date_of_birth}</Text>
-                    </>
-                  ) : (
-                    <ActivityIndicator color={colors.primary} style={{ marginTop: 12 }} />
-                  )}
-                </View>
-                {/* Allergies Section */}
-                <Text style={{ fontWeight: 'bold', fontSize: 16, marginBottom: 8, color: colors.text }}>Allergies</Text>
-                <View style={{ marginBottom: spacing.lg }}>
-                  {profile?.allergies?.length ? (
-                    profile.allergies.map((allergy) => (
-                      <Text key={allergy} style={{ color: colors.muted, fontSize: 15, marginBottom: 2 }}>• {allergy}</Text>
-                    ))
-                  ) : (
-                    <Text style={{ color: colors.muted }}>No allergies listed.</Text>
-                  )}
-                </View>
-                {/* Urgent Contact Section */}
-                <Text style={{ fontWeight: 'bold', fontSize: 16, marginBottom: 8, color: colors.text }}>Urgent Contact</Text>
-                <View style={{ marginBottom: spacing.lg }}>
-                  {profile?.emergency_contacts?.length ? (
-                    <>
-                      <Text style={{ color: colors.text, fontWeight: '600' }}>{profile.emergency_contacts[0].name}</Text>
-                      <Text style={{ color: colors.muted }}>{profile.emergency_contacts[0].phone}</Text>
-                      <Text style={{ color: colors.muted }}>{profile.emergency_contacts[0].relationship}</Text>
-                    </>
-                  ) : (
-                    <Text style={{ color: colors.muted }}>No urgent contact listed.</Text>
-                  )}
-                </View>
-                {/* Other Info Section */}
-                <Text style={{ fontWeight: 'bold', fontSize: 16, marginBottom: 8, color: colors.text }}>Other Info</Text>
-                <View style={{ marginBottom: spacing.lg }}>
-                  {profile && (
-                    <>
-                      {profile.blood_type && <Text style={{ color: colors.muted }}>Blood Type: {profile.blood_type}</Text>}
-                      {profile.medical_conditions && profile.medical_conditions.length > 0 && (
-                        <Text style={{ color: colors.muted }}>Conditions: {profile.medical_conditions.join(', ')}</Text>
-                      )}
-                      {profile.medications && profile.medications.length > 0 && (
-                        <Text style={{ color: colors.muted }}>Medications: {profile.medications.join(', ')}</Text>
-                      )}
-                    </>
-                  )}
-                </View>
-              </ScrollView>
-            </View>
-          </View>
-        </Modal>
-  </ScrollView>
       </LinearGradient>
-    </SafeAreaView>
+
+      <Card style={styles.sectionCard}>
+        <View style={styles.sectionHeader}>
+          <Text style={styles.sectionTitle}>Today's progress</Text>
+          <Text style={styles.sectionMeta}>{pillsDone.done}/{pillsDone.total}</Text>
+        </View>
+        <ProgressBar progress={progress} style={{ marginTop: 12 }} />
+        <Text style={styles.sectionHint}>Stay consistent and keep logging your doses.</Text>
+      </Card>
+
+      <Pressable
+        onPress={() => setUrgentCareModal(true)}
+        style={styles.urgentButton}
+        android_ripple={{ color: colors.primary600 }}
+        accessibilityRole="button"
+        accessibilityLabel="Open urgent care"
+        accessibilityHint="View nearby urgent care facilities and emergency contacts"
+        hitSlop={8}
+      >
+        <LinearGradient colors={colors.accentGradient} start={{ x: 0, y: 0 }} end={{ x: 1, y: 1 }} style={styles.urgentGradient}>
+          <Text style={styles.urgentLabel}>Urgent Care</Text>
+          <Text style={styles.urgentSub}>Access emergency contacts & open facilities nearby</Text>
+        </LinearGradient>
+      </Pressable>
+
+      <Card style={styles.sectionCard}>
+        <View style={styles.sectionHeader}>
+          <Text style={styles.sectionTitle}>Active reminders</Text>
+        </View>
+        <View style={styles.sectionBody}>{renderReminders()}</View>
+      </Card>
+
+      <Card style={styles.sectionCard}>
+        <View style={styles.sectionHeader}>
+          <Text style={styles.sectionTitle}>My medications</Text>
+        </View>
+        <MyMedicationsList />
+      </Card>
+
+      <Card style={styles.sectionCard}>
+        <Text style={styles.sectionTitle}>Our services</Text>
+        <View style={styles.servicesGrid}>
+          <View style={styles.serviceItem}>
+            <View style={styles.serviceIconWrap}><MaterialCommunityIcons name="barcode-scan" size={22} color={colors.primary} /></View>
+            <Text style={styles.serviceLabel}>Meds verification</Text>
+          </View>
+          <View style={styles.serviceItem}>
+            <View style={styles.serviceIconWrap}><Ionicons name="medkit" size={20} color={colors.primary} /></View>
+            <Text style={styles.serviceLabel}>Medical ID</Text>
+          </View>
+          <View style={styles.serviceItem}>
+            <View style={styles.serviceIconWrap}><Ionicons name="business" size={20} color={colors.primary} /></View>
+            <Text style={styles.serviceLabel}>Facilities</Text>
+          </View>
+        </View>
+      </Card>
+
+      <NotificationsSheet visible={notificationsVisible} onClose={() => setNotificationsVisible(false)} />
+
+      <Modal visible={urgentCareModal} animationType="slide" transparent onRequestClose={() => setUrgentCareModal(false)}>
+        <View style={styles.modalOverlay}>
+          <View style={styles.facilityModalSheet}>
+            <ScrollView contentContainerStyle={{ paddingBottom: 40 }}>
+              <View style={styles.modalHeaderRow}>
+                <Text style={styles.modalTitle}>Urgent Care</Text>
+                <Pressable onPress={() => setUrgentCareModal(false)} hitSlop={10} accessibilityRole="button" accessibilityLabel="Close urgent care sheet">
+                  <Text style={styles.modalCloseText}>Close</Text>
+                </Pressable>
+              </View>
+              <Text style={styles.sectionTitle}>Emergency contacts</Text>
+              <View style={{ marginBottom: spacing.lg }}>
+                {profile?.emergency_contacts?.length ? (
+                  profile.emergency_contacts.map(contact => (
+                    <View key={contact.phone ?? contact.name} style={styles.contactBlock}>
+                      <Text style={styles.contactName}>{contact.name}</Text>
+                      <Text style={styles.sectionText}>{contact.phone}</Text>
+                      <Text style={styles.sectionText}>{contact.relationship}</Text>
+                      <Pressable onPress={() => Linking.openURL(`tel:${contact.phone}`)} style={{ marginTop: 6 }} accessibilityRole="button">
+                        <Text style={styles.callLink}>Call</Text>
+                      </Pressable>
+                    </View>
+                  ))
+                ) : (
+                  <Text style={styles.sectionText}>No emergency contacts listed.</Text>
+                )}
+              </View>
+              <Text style={styles.sectionTitle}>Open & nearby facilities</Text>
+              <View style={{ marginBottom: spacing.lg }}>
+                {sortByDistance(facilities.filter(f => f.isOpen && (f.type === 'clinic' || f.type === 'hospital' || f.type === 'pharmacy'))).map((fac: Facility) => (
+                  <View key={fac.id} style={styles.facilityItem}>
+                    <Text style={styles.facilityName}>{fac.name} <Text style={styles.facilityMeta}>({fac.type})</Text></Text>
+                    <Text style={styles.sectionText}>{fac.location}</Text>
+                    {'phoneNumber' in fac && fac.phoneNumber && <Text style={styles.sectionText}>Phone: {fac.phoneNumber}</Text>}
+                    <Text style={styles.sectionText}>Distance: {fac.distance || 'N/A'}</Text>
+                    {'phoneNumber' in fac && fac.phoneNumber && (
+                      <Pressable onPress={() => Linking.openURL(`tel:${fac.phoneNumber}`)} style={{ marginTop: 6 }} accessibilityRole="button">
+                        <Text style={styles.callLink}>Call</Text>
+                      </Pressable>
+                    )}
+                  </View>
+                ))}
+              </View>
+            </ScrollView>
+          </View>
+        </View>
+      </Modal>
+
+      <Modal visible={profileModal} animationType="slide" transparent onRequestClose={() => setProfileModal(false)}>
+        <View style={styles.modalOverlay}>
+          <View style={styles.profileSheet}>
+            <ScrollView contentContainerStyle={{ paddingBottom: 40 }}>
+              <View style={styles.modalHeaderRow}>
+                <Text style={styles.modalTitle}>Profile</Text>
+                <Pressable onPress={() => setProfileModal(false)} hitSlop={10}>
+                  <Text style={styles.modalCloseText}>Close</Text>
+                </Pressable>
+              </View>
+              <View style={{ alignItems: 'center', marginBottom: spacing.lg }}>
+                <SkeletonImage source={AVATAR_PLACEHOLDER} style={styles.profileAvatar} resizeMode="cover" />
+                {profile ? (
+                  <>
+                    <Text style={styles.profileName}>{profile.name}</Text>
+                    <Text style={styles.sectionText}>{profile.email}</Text>
+                    <Text style={styles.sectionText}>{profile.phone}</Text>
+                    <Text style={styles.sectionText}>{profile.date_of_birth}</Text>
+                  </>
+                ) : (
+                  <ActivityIndicator color={colors.primary} style={{ marginTop: 12 }} />
+                )}
+              </View>
+              <Text style={styles.sectionTitle}>Allergies</Text>
+              <View style={{ marginBottom: spacing.lg }}>
+                {profile?.allergies?.length ? (
+                  profile.allergies.map((allergy) => (
+                    <Text key={allergy} style={styles.sectionText}>• {allergy}</Text>
+                  ))
+                ) : (
+                  <Text style={styles.sectionText}>No allergies listed.</Text>
+                )}
+              </View>
+              <Text style={styles.sectionTitle}>Urgent contact</Text>
+              <View style={{ marginBottom: spacing.lg }}>
+                {profile?.emergency_contacts?.length ? (
+                  <>
+                    <Text style={styles.contactName}>{profile.emergency_contacts[0].name}</Text>
+                    <Text style={styles.sectionText}>{profile.emergency_contacts[0].phone}</Text>
+                    <Text style={styles.sectionText}>{profile.emergency_contacts[0].relationship}</Text>
+                  </>
+                ) : (
+                  <Text style={styles.sectionText}>No urgent contact listed.</Text>
+                )}
+              </View>
+              <Text style={styles.sectionTitle}>Other info</Text>
+              <View style={{ marginBottom: spacing.lg }}>
+                {profile && (
+                  <>
+                    {profile.blood_type && <Text style={styles.sectionText}>Blood Type: {profile.blood_type}</Text>}
+                    {profile.medical_conditions && profile.medical_conditions.length > 0 && (
+                      <Text style={styles.sectionText}>Conditions: {profile.medical_conditions.join(', ')}</Text>
+                    )}
+                    {profile.medications && profile.medications.length > 0 && (
+                      <Text style={styles.sectionText}>Medications: {profile.medications.join(', ')}</Text>
+                    )}
+                  </>
+                )}
+              </View>
+            </ScrollView>
+          </View>
+        </View>
+      </Modal>
+    </ScreenContainer>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: colors.bg },
-  flex: { flex: 1 },
-  scrollContent: { flexGrow: 1 },
-  dashboardHeader: {
-    paddingHorizontal: spacing.xl,
-    paddingTop: spacing.xxl,
-    paddingBottom: 0,
-    position: 'relative',
-    minHeight: 260,
-    borderBottomLeftRadius: 36,
-    borderBottomRightRadius: 36,
-    overflow: 'hidden',
-    backgroundColor: 'transparent',
+  content: {
+    gap: spacing.xl,
+    paddingBottom: spacing.xxl,
   },
+  heroCard: {
+    borderRadius: radius.xl,
+    padding: spacing.xl,
+    gap: spacing.md,
+    ...shadow.card,
+  },
+  heroTopRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  avatarBtn: {
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+    overflow: 'hidden',
+    borderWidth: 2,
+    borderColor: 'rgba(255,255,255,0.55)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(255,255,255,0.18)',
+  },
+  avatar: { width: 44, height: 44, borderRadius: 22 },
+  heroTitle: { color: '#FFFFFF' },
+  heroSubtitle: { color: 'rgba(255,255,255,0.85)' },
   searchWrap: {
-    marginTop: 10,
+    marginTop: spacing.sm,
     flexDirection: 'row',
     alignItems: 'center',
-    backgroundColor: colors.card,
-    borderRadius: 14,
-    borderWidth: 1,
-    borderColor: colors.line,
-    paddingVertical: 8,
-    ...shadow.soft,
+    backgroundColor: 'rgba(255,255,255,0.92)',
+    borderRadius: radius.lg,
+    paddingHorizontal: 14,
+    paddingVertical: Platform.OS === 'ios' ? 12 : 10,
   },
   searchInput: {
     flex: 1,
     color: colors.text,
-    paddingRight: 12,
     fontSize: 15,
   },
   chipsRow: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    gap: 8,
-    marginTop: 14,
+    gap: 10,
+    marginTop: spacing.md,
   },
-  progressCard: {
-    marginTop: 16,
-    backgroundColor: colors.card,
-    borderRadius: 16,
-    padding: 14,
-    borderWidth: 1,
-    borderColor: colors.line,
-    ...shadow.soft,
+  sectionCard: {
+    gap: spacing.md,
   },
-  headerRow: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
-  doctorImage: {
-    position: 'absolute',
-    right: 0,
-    bottom: 0,
-    width: 140,
-    height: 160,
-    resizeMode: 'contain',
-    opacity: 0.95,
+  sectionHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
   },
-  servicesCard: {
-    backgroundColor: colors.surface,
-    borderRadius: radius.xl,
-    marginHorizontal: spacing.xl,
-    marginTop: -30,
-    padding: 20,
+  sectionTitle: { fontWeight: '700', fontSize: 17, color: colors.text },
+  sectionMeta: { color: colors.muted, fontWeight: '600' },
+  sectionHint: { color: colors.muted, fontSize: 13 },
+  sectionBody: { gap: spacing.md },
+  urgentButton: {
+    borderRadius: radius.pill,
+    overflow: 'hidden',
     ...shadow.card,
+  },
+  urgentGradient: {
+    paddingVertical: 18,
+    paddingHorizontal: spacing.xl,
+    alignItems: 'center',
+  },
+  urgentLabel: { color: '#fff', fontWeight: '700', fontSize: 17 },
+  urgentSub: { color: 'rgba(255,255,255,0.85)', marginTop: 4, fontSize: 13, textAlign: 'center' },
+  servicesGrid: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    gap: spacing.md,
   },
   serviceItem: {
-    alignItems: 'center',
     flex: 1,
-  },
-  serviceIcon: {
-    fontSize: 32,
-    marginBottom: 4,
+    alignItems: 'center',
+    gap: 6,
   },
   serviceIconWrap: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    backgroundColor: colors.chipBg,
+    width: 52,
+    height: 52,
+    borderRadius: 26,
+    backgroundColor: 'rgba(37,99,235,0.16)',
     alignItems: 'center',
     justifyContent: 'center',
-    marginBottom: 6,
   },
-  serviceLabel: {
-    fontSize: 13,
-    color: colors.muted,
-    fontWeight: '600',
-  },
-  appointmentCard: {
-    backgroundColor: colors.surface,
-    borderRadius: radius.xl,
-    marginHorizontal: spacing.xl,
-    marginTop: 24,
-    padding: 20,
-    ...shadow.card,
-  },
-  appointmentItem: {
-    backgroundColor: colors.line,
-    borderRadius: radius.md,
-    padding: spacing.md,
-    marginTop: 8,
-  },
-  appointmentAvatar: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    resizeMode: 'cover',
-  },
-  bell: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    backgroundColor: colors.card,
-    alignItems: 'center',
-    justifyContent: 'center',
-    ...shadow.card,
-  },
-  avatarBtn: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    overflow: 'hidden',
-    marginLeft: 8,
-  backgroundColor: colors.surface,
-    alignItems: 'center',
-    justifyContent: 'center',
-    ...shadow.card,
-  },
-  avatar: {
-    width: 36,
-    height: 36,
-    borderRadius: 18,
-    resizeMode: 'cover',
-  },
-  facilityModalSheet: {
-    borderTopLeftRadius: 34,
-    borderTopRightRadius: 34,
-    paddingTop: 32,
-    paddingHorizontal: 28,
-    minHeight: '60%',
-    maxHeight: '90%',
-    backgroundColor: colors.surface,
-    overflow: 'hidden',
-  },
-  profileAvatar: {
-    width: 80,
-    height: 80,
-    borderRadius: 40,
-    borderWidth: 3,
-    borderColor: colors.card,
-    marginBottom: 8,
-    resizeMode: 'cover',
-  },
+  serviceLabel: { fontSize: 13, color: colors.text, fontWeight: '600', textAlign: 'center' },
+  notifications: {},
   modalOverlay: { flex: 1, backgroundColor: colors.overlay, justifyContent: 'flex-end' },
-  modalHeaderRow: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 18 },
-  modalTitle: { fontWeight: '700', fontSize: 22, color: colors.text },
-  modalCloseText: { color: colors.muted, fontWeight: '600', fontSize: 16 },
-  sectionTitle: { fontWeight: '700', fontSize: 16, marginBottom: 8, color: colors.text },
-  contactBlock: { marginBottom: 8 },
-  contactName: { color: colors.text, fontWeight: '600' },
-  sectionText: { color: colors.muted },
-  callLink: { color: colors.primary, fontWeight: '600' },
-  facilityItem: { marginBottom: 12 },
-  facilityName: { color: colors.text, fontWeight: '600' },
-  facilityMeta: { color: colors.muted, fontWeight: '400' },
-  cta: {
-    marginHorizontal: spacing.xl,
-    backgroundColor: colors.primary,
-    paddingVertical: 16,
-    borderRadius: 999,
-    alignItems: 'center',
-    marginBottom: spacing.xl,
+  facilityModalSheet: {
+    borderTopLeftRadius: radius.xl,
+    borderTopRightRadius: radius.xl,
+    padding: spacing.xl,
+    paddingBottom: 40,
+    backgroundColor: colors.glass,
     ...shadow.card,
   },
-  ctaText: { color: colors.card, fontWeight: '700' },
-  welcome: { marginTop: 18 },
-  subheading: { marginBottom: 18 },
-  grid: {
-    paddingHorizontal: spacing.xl,
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    gap: spacing.xl,
+  profileSheet: {
+    borderTopLeftRadius: radius.xl,
+    borderTopRightRadius: radius.xl,
+    padding: spacing.xl,
+    paddingBottom: 40,
+    backgroundColor: colors.glass,
+    ...shadow.card,
   },
-  tile: {
-    width: '46%',
-    alignSelf: 'stretch',
+  modalHeaderRow: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 18 },
+  modalTitle: { fontWeight: 'bold', fontSize: 22, color: colors.text },
+  modalCloseText: { color: colors.muted, fontWeight: '600', fontSize: 16 },
+  sectionText: { color: colors.muted, fontSize: 14, marginTop: 2 },
+  contactBlock: { marginBottom: spacing.md },
+  contactName: { color: colors.text, fontWeight: '600' },
+  callLink: { color: colors.primary, fontWeight: '600' },
+  facilityItem: {
+    marginBottom: spacing.md,
+    paddingBottom: spacing.sm,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.line,
   },
+  facilityName: { color: colors.text, fontWeight: '600' },
+  facilityMeta: { color: colors.muted },
+  profileAvatar: {
+    width: 88,
+    height: 88,
+    borderRadius: 44,
+    borderWidth: 3,
+    borderColor: colors.surface,
+    marginBottom: 8,
+  },
+  profileName: { fontWeight: '700', fontSize: 22, color: colors.text, marginTop: 8 },
+  reminderCard: {
+    backgroundColor: 'rgba(37,99,235,0.08)',
+    borderRadius: radius.lg,
+    padding: spacing.md,
+    gap: 6,
+  },
+  reminderTitle: { color: colors.text, fontWeight: '600', fontSize: 15 },
+  reminderMeta: { color: colors.muted, fontSize: 13 },
+  reminderDescription: { color: colors.muted, fontSize: 13 },
+  reminderBadge: {
+    backgroundColor: 'rgba(255,255,255,0.86)',
+    borderRadius: radius.pill,
+    paddingHorizontal: 12,
+    paddingVertical: 4,
+  },
+  reminderBadgeText: { color: colors.primary, fontWeight: '600', fontSize: 12 },
 });

--- a/src/screens/DrugInfo.tsx
+++ b/src/screens/DrugInfo.tsx
@@ -1,103 +1,193 @@
 import React, { useState } from 'react';
-import { View, Text, TextInput, ScrollView, Pressable, StyleSheet, ActivityIndicator } from 'react-native';
+import { View, Text, TextInput, Pressable, StyleSheet, ActivityIndicator } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
-import { useDrugInfo } from '../hooks/useDrugInfo';
-import { colors, spacing, radius, type } from '../theme';
+import { LinearGradient } from 'expo-linear-gradient';
+import ScreenContainer from '../components/ScreenContainer';
 import Card from '../components/Card';
 import { ListRow } from '../components/ListRow';
 import { Pill } from '../components/Pill';
+import Chip from '../components/Chip';
+import { useDrugInfo } from '../hooks/useDrugInfo';
+import { colors, spacing, radius, type } from '../theme';
 
 export default function DrugInfo({ navigation }: any) {
   const { searchDrug, suggestions, loading, error } = useDrugInfo();
   const [query, setQuery] = useState('');
   const [drugInfo, setDrugInfo] = useState<any>(null);
+  const [activeFilter, setActiveFilter] = useState('By Name');
 
-  const handleSearch = async () => {
-    const result = await searchDrug(query);
+  const handleSearch = async (value?: string) => {
+    const text = value ?? query;
+    setQuery(text);
+    if (!text) {
+      setDrugInfo(null);
+      return;
+    }
+    const result = await searchDrug(text);
     setDrugInfo(result);
   };
 
-  return (
-    <View style={{ flex: 1, backgroundColor: colors.bg }}>
-      <View style={styles.top}>
-        <View style={styles.searchBar}>
-          <Ionicons name="search" size={20} color={colors.muted} />
-          <TextInput
-            style={{ flex: 1, marginLeft: spacing.sm }}
-            placeholder="Search drugs"
-            value={query}
-            onChangeText={setQuery}
-            onSubmitEditing={handleSearch}
-            returnKeyType="search"
-          />
-        </View>
-        <View style={styles.filters}>
-          {['By Name', 'By Use', 'By Category'].map(opt => (
-            <Pressable key={opt} style={styles.chip} android_ripple={{ color: colors.line }}>
-              <Text style={styles.chipText}>{opt}</Text>
-            </Pressable>
-          ))}
-        </View>
+  const hero = (
+    <LinearGradient colors={colors.primaryGradient} start={{ x: 0, y: 0 }} end={{ x: 1, y: 1 }} style={styles.hero}>
+      <Text style={styles.heroTitle}>Medication encyclopedia</Text>
+      <Text style={styles.heroSubtitle}>Search trusted sources for drug insights, dosage guidance, and risk highlights.</Text>
+      <View style={styles.searchBar}>
+        <Ionicons name="search" size={18} color={colors.muted} />
+        <TextInput
+          style={styles.searchInput}
+          placeholder="Search drugs"
+          placeholderTextColor={colors.muted}
+          value={query}
+          onChangeText={setQuery}
+          onSubmitEditing={() => handleSearch()}
+          returnKeyType="search"
+        />
+        <Pressable
+          style={styles.searchAction}
+          onPress={() => handleSearch()}
+        >
+          <Text style={styles.searchActionText}>Go</Text>
+        </Pressable>
       </View>
-      <ScrollView contentContainerStyle={{ padding: spacing.xl, gap: spacing.lg }}>
-        {suggestions.map(drug => (
-          <Card key={drug}>
+      <View style={styles.filterRow}>
+        {['By Name', 'By Use', 'By Category'].map(opt => (
+          <Chip key={opt} label={opt} selected={activeFilter === opt} onPress={() => setActiveFilter(opt)} />
+        ))}
+      </View>
+    </LinearGradient>
+  );
+
+  return (
+    <ScreenContainer
+      scrollable
+      contentContainerStyle={styles.content}
+      header={hero}
+    >
+      {suggestions.length > 0 ? (
+        <Card style={styles.sectionCard}>
+          <Text style={styles.sectionTitle}>Suggested matches</Text>
+          {suggestions.map(drug => (
             <ListRow
+              key={drug}
               title={drug}
-              onPress={() => {
-                setQuery(drug);
-                handleSearch();
-              }}
+              subtitle="Tap to view detailed information"
+              onPress={() => handleSearch(drug)}
               right={<Ionicons name="information-circle-outline" size={20} color={colors.primary} />}
             />
-          </Card>
-        ))}
-        {loading && <ActivityIndicator size="large" color={colors.primary} />}
-        {error && <Text style={{ color: colors.danger }}>{error}</Text>}
-        {drugInfo && (
-          <Card>
-            <Text style={[type.h2, { marginBottom: spacing.sm }]}>{drugInfo.name}</Text>
-            {drugInfo.description && <Text style={{ marginBottom: spacing.md }}>{drugInfo.description}</Text>}
-            {drugInfo.warnings && drugInfo.warnings.length > 0 && (
-              <Pill tone="warn">Warning</Pill>
-            )}
-            {drugInfo.dosage && (
-              <Text style={styles.section}>Dosage: {drugInfo.dosage}</Text>
-            )}
-            {drugInfo.side_effects && (
-              <Text style={styles.section}>Side Effects: {drugInfo.side_effects.join(', ')}</Text>
-            )}
-            {drugInfo.interactions && (
-              <Text style={styles.section}>Interactions: {drugInfo.interactions.join(', ')}</Text>
-            )}
-          </Card>
-        )}
-      </ScrollView>
-    </View>
+          ))}
+        </Card>
+      ) : null}
+
+      {loading ? <ActivityIndicator size="large" color={colors.primary} /> : null}
+      {error ? <Text style={styles.errorText}>{error}</Text> : null}
+
+      {drugInfo ? (
+        <Card style={styles.sectionCard}>
+          <View style={styles.headerRow}>
+            <Text style={styles.sectionTitle}>{drugInfo.name}</Text>
+            {drugInfo.warnings && drugInfo.warnings.length > 0 ? <Pill tone="warn">Warning</Pill> : null}
+          </View>
+          {drugInfo.description ? <Text style={styles.bodyText}>{drugInfo.description}</Text> : null}
+          {drugInfo.dosage ? <Text style={styles.bodyText}>Dosage: {drugInfo.dosage}</Text> : null}
+          {drugInfo.side_effects ? <Text style={styles.bodyText}>Side effects: {drugInfo.side_effects.join(', ')}</Text> : null}
+          {drugInfo.interactions ? <Text style={styles.bodyText}>Interactions: {drugInfo.interactions.join(', ')}</Text> : null}
+        </Card>
+      ) : (
+        <Card style={styles.emptyState}>
+          <Ionicons name="medical-outline" size={26} color={colors.primary} />
+          <Text style={styles.emptyTitle}>No drug selected</Text>
+          <Text style={styles.emptyText}>Search to view FDA-backed monographs, interactions, and dosage guides.</Text>
+        </Card>
+      )}
+    </ScreenContainer>
   );
 }
 
 const styles = StyleSheet.create({
-  top: { padding: spacing.xl },
+  content: {
+    paddingHorizontal: spacing.xl,
+    paddingBottom: spacing.xxl,
+    gap: spacing.lg,
+  },
+  hero: {
+    paddingTop: spacing.xxl * 1.2,
+    paddingBottom: spacing.xxl,
+    paddingHorizontal: spacing.xl,
+    borderBottomLeftRadius: radius.xl + 6,
+    borderBottomRightRadius: radius.xl + 6,
+    gap: spacing.md,
+  },
+  heroTitle: {
+    ...type.h1,
+    color: '#fff',
+  },
+  heroSubtitle: {
+    color: 'rgba(255,255,255,0.78)',
+    lineHeight: 20,
+  },
   searchBar: {
     flexDirection: 'row',
     alignItems: 'center',
-    backgroundColor: colors.card,
+    backgroundColor: 'rgba(255,255,255,0.85)',
     borderRadius: radius.lg,
     paddingHorizontal: spacing.lg,
     paddingVertical: spacing.sm,
-  },
-  filters: {
-    flexDirection: 'row',
-    marginTop: spacing.md,
     gap: spacing.sm,
   },
-  chip: {
-  backgroundColor: '#EFF3FF',
+  searchInput: {
+    flex: 1,
+    fontSize: 16,
+    color: colors.text,
+  },
+  searchAction: {
+    backgroundColor: colors.primary,
+    borderRadius: radius.md,
     paddingHorizontal: spacing.md,
     paddingVertical: spacing.xs,
-    borderRadius: radius.md,
   },
-  chipText: { color: colors.muted, fontWeight: '600' },
-  section: { marginTop: spacing.sm },
+  searchActionText: {
+    color: colors.card,
+    fontWeight: '700',
+  },
+  filterRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.sm,
+  },
+  sectionCard: {
+    gap: spacing.md,
+  },
+  sectionTitle: {
+    ...type.h2,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: spacing.sm,
+  },
+  bodyText: {
+    color: colors.text,
+    lineHeight: 20,
+  },
+  errorText: {
+    color: colors.danger,
+    textAlign: 'center',
+    fontWeight: '600',
+  },
+  emptyState: {
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingVertical: spacing.xl,
+  },
+  emptyTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: colors.text,
+  },
+  emptyText: {
+    color: colors.muted,
+    textAlign: 'center',
+    lineHeight: 20,
+  },
 });

--- a/src/screens/FacilityDetail.tsx
+++ b/src/screens/FacilityDetail.tsx
@@ -1,7 +1,7 @@
 
 import React, { useEffect, useRef } from 'react';
 import { View, Text, StyleSheet, Pressable, useWindowDimensions, Image as RNImage } from 'react-native';
-import { colors, spacing, type, radius } from '../theme';
+import { colors, spacing, type, radius, shadow } from '../theme';
 import { useRoute, useNavigation } from '@react-navigation/native';
 import { useFacilities } from '../hooks/useFacilitiesFirestore';
 import { Pill } from '../components/Pill';
@@ -86,16 +86,12 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-end',
   },
   sheet: {
-    backgroundColor: colors.card,
+    backgroundColor: colors.glass,
     borderTopLeftRadius: radius.xl,
     borderTopRightRadius: radius.xl,
     padding: spacing.xl,
     paddingBottom: 40,
-    shadowColor: '#000',
-    shadowOpacity: 0.08,
-    shadowRadius: 12,
-    shadowOffset: { width: 0, height: -4 },
-    elevation: 8,
+    ...shadow.card,
   },
   headerRow: {
     flexDirection: 'row',
@@ -129,5 +125,6 @@ const styles = StyleSheet.create({
     color: colors.text,
     fontSize: 15,
     marginBottom: 4,
+    lineHeight: 20,
   },
 });

--- a/src/screens/Login.tsx
+++ b/src/screens/Login.tsx
@@ -1,26 +1,68 @@
 import React, { useState } from 'react';
-import { Platform } from 'react-native';
-import BloodTypePicker from '../components/BloodTypePicker';
-import { View, Text, TextInput, Pressable, StyleSheet, Alert, Image, ActivityIndicator } from 'react-native';
+import {
+  Platform,
+  View,
+  Text,
+  TextInput,
+  Pressable,
+  StyleSheet,
+  Alert,
+  Image,
+  ActivityIndicator,
+  KeyboardAvoidingView,
+} from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
-import { sendPasswordResetEmail } from 'firebase/auth';
-import { signInWithEmailAndPassword, createUserWithEmailAndPassword } from 'firebase/auth';
-import { auth, db } from '../lib/firebase';
+import { sendPasswordResetEmail, signInWithEmailAndPassword, createUserWithEmailAndPassword } from 'firebase/auth';
 import { doc, setDoc } from 'firebase/firestore';
-import { colors, spacing, type } from '../theme';
+import { LinearGradient } from 'expo-linear-gradient';
+import BloodTypePicker from '../components/BloodTypePicker';
+import ScreenContainer from '../components/ScreenContainer';
+import Card from '../components/Card';
+import { SegmentedControl } from '../components/SegmentedControl';
+import { auth, db } from '../lib/firebase';
+import { colors, spacing, type, radius } from '../theme';
 
-export default function Login({ navigation, onLogin }: { navigation?: any; onLogin?: () => void }) {
+type LoginProps = { navigation?: any; onLogin?: () => void };
+
+type StepKey = 0 | 1;
+
+type RegisterErrorState = {
+  email?: string;
+  password?: string;
+  confirmPassword?: string;
+};
+
+type RegisterPersonalErrors = {
+  name?: string;
+  phone?: string;
+  dateOfBirth?: string;
+};
+
+type HealthErrors = {
+  bloodType?: string;
+  allergies?: string;
+  conditions?: string;
+};
+
+const STEPS: { key: StepKey; label: string }[] = [
+  { key: 0, label: 'Account' },
+  { key: 1, label: 'Personal' },
+];
+
+export default function Login({ navigation, onLogin }: Readonly<LoginProps>) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [isRegister, setIsRegister] = useState(false);
-  const [registerStep, setRegisterStep] = useState(0);
+  const [registerStep, setRegisterStep] = useState<StepKey>(0);
   const [focusedInput, setFocusedInput] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+
   // Personal info fields
   const [name, setName] = useState('');
   const [phone, setPhone] = useState('');
   const [dateOfBirth, setDateOfBirth] = useState('');
+
   // Health fields
   const [bloodType, setBloodType] = useState('');
   const [customBloodType, setCustomBloodType] = useState('');
@@ -28,24 +70,22 @@ export default function Login({ navigation, onLogin }: { navigation?: any; onLog
   const [allergies, setAllergies] = useState<string[]>([]);
   const [conditionInput, setConditionInput] = useState('');
   const [medicalConditions, setMedicalConditions] = useState<string[]>([]);
-  const [healthErrors, setHealthErrors] = useState<{ bloodType?: string; allergies?: string; conditions?: string }>({});
+
+  // Error states
+  const [loginErrors, setLoginErrors] = useState<{ email?: string; password?: string }>({});
+  const [registerAccountErrors, setRegisterAccountErrors] = useState<RegisterErrorState>({});
+  const [registerPersonalErrors, setRegisterPersonalErrors] = useState<RegisterPersonalErrors>({});
+  const [healthErrors, setHealthErrors] = useState<HealthErrors>({});
 
   // Forgot password dialog state
   const [showForgot, setShowForgot] = useState(false);
   const [forgotEmail, setForgotEmail] = useState('');
   const [forgotLoading, setForgotLoading] = useState(false);
 
-  // Inline error state for login fields
-  const [loginErrors, setLoginErrors] = useState<{ email?: string; password?: string }>({});
-  // Inline error state for register fields (account step)
-  const [registerAccountErrors, setRegisterAccountErrors] = useState<{ email?: string; password?: string; confirmPassword?: string }>({});
-  // Inline error state for register fields (personal step)
-  const [registerPersonalErrors, setRegisterPersonalErrors] = useState<{ name?: string; phone?: string; dateOfBirth?: string }>({});
-
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
   const validateLogin = () => {
-    let errors: { email?: string; password?: string } = {};
+    const errors: { email?: string; password?: string } = {};
     if (!email) {
       errors.email = 'Email is required.';
     } else if (!emailRegex.test(email)) {
@@ -59,7 +99,7 @@ export default function Login({ navigation, onLogin }: { navigation?: any; onLog
   };
 
   const validateAccountStep = () => {
-    let errors: { email?: string; password?: string; confirmPassword?: string } = {};
+    const errors: RegisterErrorState = {};
     if (!email) {
       errors.email = 'Email is required.';
     } else if (!emailRegex.test(email)) {
@@ -80,8 +120,8 @@ export default function Login({ navigation, onLogin }: { navigation?: any; onLog
   };
 
   const validatePersonalStep = () => {
-    let errors: { name?: string; phone?: string; dateOfBirth?: string } = {};
-    let health: { bloodType?: string; allergies?: string; conditions?: string } = {};
+    const errors: RegisterPersonalErrors = {};
+    const health: HealthErrors = {};
     if (!name.trim()) {
       errors.name = 'Full name is required.';
     }
@@ -91,16 +131,13 @@ export default function Login({ navigation, onLogin }: { navigation?: any; onLog
     if (dateOfBirth && !/^\d{4}-\d{2}-\d{2}$/.test(dateOfBirth)) {
       errors.dateOfBirth = 'Date of Birth must be in YYYY-MM-DD format.';
     }
-    // Blood type validation
     const bt = bloodType === 'custom' ? customBloodType.trim() : bloodType;
     if (bt && !/^A[+-]$|^B[+-]$|^AB[+-]$|^O[+-]$/.test(bt)) {
       health.bloodType = 'Blood type must be A+, A-, B+, B-, AB+, AB-, O+, or O-.';
     }
-    // Allergies validation
     if (allergies.some(a => !a.trim())) {
       health.allergies = 'Allergy cannot be empty.';
     }
-    // Conditions validation
     if (medicalConditions.some(c => !c.trim())) {
       health.conditions = 'Condition cannot be empty.';
     }
@@ -160,551 +197,663 @@ export default function Login({ navigation, onLogin }: { navigation?: any; onLog
     }
   };
 
-  return (
-    <View style={[styles.container, Platform.OS === 'web' ? { backgroundImage: 'linear-gradient(135deg, #F3F6FF 0%, #FFFFFF 60%)' } as any : null]}>
-      <View style={styles.card}>
-        <View style={{ alignItems: 'center', marginBottom: 24 }}>
-          <Image
-            source={require('../assets/logo.png')}
-            style={{ width: 100, height: 100, resizeMode: 'contain', marginBottom: 8 }}
-          />
-          <Text style={[type.h1, { marginBottom: 8 }]}>
-            {isRegister ? 'Create Account' : 'Login'}
-          </Text>
-        </View>
-        {isRegister && (
-          <View style={styles.stepper}>
-            <View style={styles.stepWrapper}>
-              <View
-                style={[styles.stepCircle, registerStep >= 0 && styles.stepCircleActive]}
-              >
-                <Text style={styles.stepNumber}>1</Text>
-              </View>
-              <Text
-                style={[styles.stepLabel, registerStep === 0 && styles.stepLabelActive]}
-              >
-                Account
-              </Text>
-            </View>
-            <View style={[styles.stepLine, registerStep > 0 && styles.stepLineActive]} />
-            <View style={styles.stepWrapper}>
-              <View
-                style={[styles.stepCircle, registerStep >= 1 && styles.stepCircleActive]}
-              >
-                <Text style={styles.stepNumber}>2</Text>
-              </View>
-              <Text
-                style={[styles.stepLabel, registerStep === 1 && styles.stepLabelActive]}
-              >
-                Personal
-              </Text>
-            </View>
-          </View>
-        )}
+  const renderInput = (
+    props: React.ComponentProps<typeof TextInput> & {
+      error?: string;
+      id: string;
+    },
+  ) => {
+    const { error, id, ...rest } = props;
+    return (
+      <View style={{ width: '100%' }}>
+        <TextInput
+          {...rest}
+          style={[
+            styles.input,
+            focusedInput === id && styles.inputFocused,
+            error && styles.inputError,
+          ]}
+          onFocus={() => setFocusedInput(id)}
+          onBlur={event => {
+            rest.onBlur?.(event);
+            setFocusedInput(null);
+          }}
+          placeholderTextColor={colors.muted}
+        />
+        {error ? <Text style={styles.errorText}>{error}</Text> : null}
+      </View>
+    );
+  };
 
-        {!isRegister && (
-          <>
-            <TextInput
-              style={[styles.input, focusedInput === 'email' && styles.inputFocused, loginErrors.email && styles.inputError]}
-              placeholder="Email"
-              autoCapitalize="none"
-              keyboardType="email-address"
-              value={email}
-              onChangeText={text => {
-                setEmail(text);
-                if (loginErrors.email) setLoginErrors(e => ({ ...e, email: undefined }));
-              }}
-              onFocus={() => setFocusedInput('email')}
-              onBlur={() => {
-                setFocusedInput(null);
-                if (!email) setLoginErrors(e => ({ ...e, email: 'Email is required.' }));
-                else if (!emailRegex.test(email)) setLoginErrors(e => ({ ...e, email: 'Please enter a valid email address.' }));
-                else setLoginErrors(e => ({ ...e, email: undefined }));
-              }}
-            />
-            {loginErrors.email ? <Text style={styles.errorText}>{loginErrors.email}</Text> : null}
-            <TextInput
-              style={[styles.input, focusedInput === 'password' && styles.inputFocused, loginErrors.password && styles.inputError]}
-              placeholder="Password"
-              secureTextEntry
-              value={password}
-              onChangeText={text => {
-                setPassword(text);
-                if (loginErrors.password) setLoginErrors(e => ({ ...e, password: undefined }));
-              }}
-              onFocus={() => setFocusedInput('password')}
-              onBlur={() => {
-                setFocusedInput(null);
-                if (!password) setLoginErrors(e => ({ ...e, password: 'Password is required.' }));
-                else setLoginErrors(e => ({ ...e, password: undefined }));
-              }}
-            />
-            {loginErrors.password ? <Text style={styles.errorText}>{loginErrors.password}</Text> : null}
-            <Pressable onPress={() => setShowForgot(true)}>
-              <Text style={{ color: colors.primary, marginTop: -4, marginBottom: 12, alignSelf: 'flex-end', textDecorationLine: 'underline' }}>Forgot password?</Text>
-            </Pressable>
-            <Pressable
-              style={[styles.button, loading && { opacity: 0.7 }]}
-              onPress={handleLogin}
-              disabled={loading}
-            >
-              {loading ? (
-                <ActivityIndicator color={colors.card} />
-              ) : (
-                <Text style={styles.buttonText}>Login</Text>
-              )}
-            </Pressable>
-            {/* Forgot Password Dialog */}
-            {showForgot && (
-                <View style={{ position: 'absolute', left: 0, top: 0, right: 0, bottom: 0, backgroundColor: colors.overlay, justifyContent: 'center', alignItems: 'center', zIndex: 10 }}>
-                <View style={{ backgroundColor: colors.card, borderRadius: 18, padding: spacing.xl, width: 340, alignItems: 'center', elevation: 7, shadowColor: '#000', shadowOpacity: 0.12, shadowRadius: 12 }}>
-                  <Ionicons name="lock-closed-outline" size={40} color={colors.primary} style={{ marginBottom: 10 }} />
-                  <Text style={{ fontWeight: 'bold', fontSize: 20, marginBottom: 8, color: colors.primary }}>Reset Password</Text>
-                  <Text style={{ color: colors.text, marginBottom: 18, textAlign: 'center', fontSize: 15, lineHeight: 20 }}>
-                    Enter your email address and we'll send you a password reset link.
-                  </Text>
-                  <TextInput
-                    style={[styles.input, { marginBottom: 0, width: '100%' }]}
-                    placeholder="Email"
-                    autoCapitalize="none"
-                    keyboardType="email-address"
-                    value={forgotEmail}
-                    onChangeText={setForgotEmail}
-                  />
-                    <View style={{ flexDirection: 'row', marginTop: 22, width: '100%', gap: 0 }}>
-                    <Pressable style={{ flex: 1, marginRight: 8, height: 48, justifyContent: 'center', alignItems: 'center', backgroundColor: colors.card, borderRadius: 8, borderWidth: 1, borderColor: colors.line }} onPress={() => { setShowForgot(false); setForgotEmail(''); }}>
-                      <Text style={styles.buttonSecondaryText}>Cancel</Text>
-                    </Pressable>
-                    <Pressable
-                      style={{ flex: 1, height: 48, justifyContent: 'center', alignItems: 'center', backgroundColor: colors.primary, borderRadius: 8 }}
-                      onPress={async () => {
-                        if (!forgotEmail || !emailRegex.test(forgotEmail)) {
-                          Alert.alert('Invalid Email', 'Please enter a valid email address.');
-                          return;
-                        }
-                        setForgotLoading(true);
-                        try {
-                          await sendPasswordResetEmail(auth, forgotEmail);
-                          Alert.alert('Password Reset', 'A password reset link has been sent to your email.');
-                          setShowForgot(false);
-                          setForgotEmail('');
-                        } catch (e: any) {
-                          Alert.alert('Error', e.message || 'Failed to send reset email.');
-                        } finally {
-                          setForgotLoading(false);
-                        }
-                      }}
-                      disabled={forgotLoading}
-                    >
-                      {forgotLoading ? <ActivityIndicator color={colors.card} /> : <Text style={styles.buttonText}>Send</Text>}
-                    </Pressable>
-                  </View>
-                </View>
-              </View>
-            )}
-          </>
-        )}
+  const renderLogin = () => (
+    <>
+      {renderInput({
+        id: 'login-email',
+        placeholder: 'Email',
+        autoCapitalize: 'none',
+        keyboardType: 'email-address',
+        value: email,
+        onChangeText: text => {
+          setEmail(text);
+          if (loginErrors.email) setLoginErrors(e => ({ ...e, email: undefined }));
+        },
+        onBlur: () => {
+          if (!email) setLoginErrors(e => ({ ...e, email: 'Email is required.' }));
+          else if (!emailRegex.test(email)) setLoginErrors(e => ({ ...e, email: 'Please enter a valid email address.' }));
+          else setLoginErrors(e => ({ ...e, email: undefined }));
+        },
+        error: loginErrors.email,
+      })}
+      {renderInput({
+        id: 'login-password',
+        placeholder: 'Password',
+        secureTextEntry: true,
+        value: password,
+        onChangeText: text => {
+          setPassword(text);
+          if (loginErrors.password) setLoginErrors(e => ({ ...e, password: undefined }));
+        },
+        onBlur: () => {
+          if (!password) setLoginErrors(e => ({ ...e, password: 'Password is required.' }));
+          else setLoginErrors(e => ({ ...e, password: undefined }));
+        },
+        error: loginErrors.password,
+      })}
+      <Pressable onPress={() => setShowForgot(true)} style={styles.forgotLink}>
+        <Text style={styles.forgotText}>Forgot password?</Text>
+      </Pressable>
+      <Pressable style={[styles.primaryButton, loading && styles.disabled]} onPress={handleLogin} disabled={loading}>
+        {loading ? <ActivityIndicator color={colors.card} /> : <Text style={styles.primaryButtonText}>Login</Text>}
+      </Pressable>
+    </>
+  );
 
-        {isRegister && registerStep === 0 && (
-          <>
-            <TextInput
-              style={[styles.input, focusedInput === 'email' && styles.inputFocused, registerAccountErrors.email && styles.inputError]}
-              placeholder="Email"
-              autoCapitalize="none"
-              keyboardType="email-address"
-              value={email}
-              onChangeText={text => {
-                setEmail(text);
-                if (registerAccountErrors.email) setRegisterAccountErrors(e => ({ ...e, email: undefined }));
-              }}
-              onFocus={() => setFocusedInput('email')}
-              onBlur={() => {
-                setFocusedInput(null);
-                if (!email) setRegisterAccountErrors(e => ({ ...e, email: 'Email is required.' }));
-                else if (!emailRegex.test(email)) setRegisterAccountErrors(e => ({ ...e, email: 'Please enter a valid email address.' }));
-                else setRegisterAccountErrors(e => ({ ...e, email: undefined }));
-              }}
-            />
-            {registerAccountErrors.email ? <Text style={styles.errorText}>{registerAccountErrors.email}</Text> : null}
-            <TextInput
-              style={[styles.input, focusedInput === 'password' && styles.inputFocused, registerAccountErrors.password && styles.inputError]}
-              placeholder="Password"
-              secureTextEntry
-              value={password}
-              onChangeText={text => {
-                setPassword(text);
-                if (registerAccountErrors.password) setRegisterAccountErrors(e => ({ ...e, password: undefined }));
-              }}
-              onFocus={() => setFocusedInput('password')}
-              onBlur={() => {
-                setFocusedInput(null);
-                if (!password) setRegisterAccountErrors(e => ({ ...e, password: 'Password is required.' }));
-                else if (password.length < 8 || !/[A-Za-z]/.test(password) || !/\d/.test(password)) setRegisterAccountErrors(e => ({ ...e, password: 'Password must be at least 8 characters and include both letters and numbers.' }));
-                else setRegisterAccountErrors(e => ({ ...e, password: undefined }));
-              }}
-            />
-            {registerAccountErrors.password ? <Text style={styles.errorText}>{registerAccountErrors.password}</Text> : null}
-            <TextInput
-              style={[styles.input, focusedInput === 'confirm' && styles.inputFocused, registerAccountErrors.confirmPassword && styles.inputError]}
-              placeholder="Confirm Password"
-              secureTextEntry
-              value={confirmPassword}
-              onChangeText={text => {
-                setConfirmPassword(text);
-                if (registerAccountErrors.confirmPassword) setRegisterAccountErrors(e => ({ ...e, confirmPassword: undefined }));
-              }}
-              onFocus={() => setFocusedInput('confirm')}
-              onBlur={() => {
-                setFocusedInput(null);
-                if (!confirmPassword) setRegisterAccountErrors(e => ({ ...e, confirmPassword: 'Please confirm your password.' }));
-                else if (password !== confirmPassword) setRegisterAccountErrors(e => ({ ...e, confirmPassword: 'Passwords do not match.' }));
-                else setRegisterAccountErrors(e => ({ ...e, confirmPassword: undefined }));
-              }}
-            />
-            {registerAccountErrors.confirmPassword ? <Text style={styles.errorText}>{registerAccountErrors.confirmPassword}</Text> : null}
-            <Pressable
-              style={[styles.button, loading && { opacity: 0.7 }]}
-              onPress={() => {
-                if (validateAccountStep()) setRegisterStep(1);
-              }}
-              disabled={loading}
-            >
-              {loading ? (
-                <ActivityIndicator color="#fff" />
-              ) : (
-                <Text style={styles.buttonText}>Next</Text>
-              )}
-            </Pressable>
-          </>
-        )}
+  const renderAccountStep = () => (
+    <>
+      {renderInput({
+        id: 'register-email',
+        placeholder: 'Email',
+        autoCapitalize: 'none',
+        keyboardType: 'email-address',
+        value: email,
+        onChangeText: text => {
+          setEmail(text);
+          if (registerAccountErrors.email) setRegisterAccountErrors(e => ({ ...e, email: undefined }));
+        },
+        onBlur: () => {
+          if (!email) setRegisterAccountErrors(e => ({ ...e, email: 'Email is required.' }));
+          else if (!emailRegex.test(email)) setRegisterAccountErrors(e => ({ ...e, email: 'Please enter a valid email address.' }));
+          else setRegisterAccountErrors(e => ({ ...e, email: undefined }));
+        },
+        error: registerAccountErrors.email,
+      })}
+      {renderInput({
+        id: 'register-password',
+        placeholder: 'Password',
+        secureTextEntry: true,
+        value: password,
+        onChangeText: text => {
+          setPassword(text);
+          if (registerAccountErrors.password) setRegisterAccountErrors(e => ({ ...e, password: undefined }));
+        },
+        onBlur: () => {
+          if (!password) setRegisterAccountErrors(e => ({ ...e, password: 'Password is required.' }));
+          else if (password.length < 8 || !/[A-Za-z]/.test(password) || !/\d/.test(password))
+            setRegisterAccountErrors(e => ({ ...e, password: 'Password must be at least 8 characters and include both letters and numbers.' }));
+          else setRegisterAccountErrors(e => ({ ...e, password: undefined }));
+        },
+        error: registerAccountErrors.password,
+      })}
+      {renderInput({
+        id: 'register-confirm',
+        placeholder: 'Confirm Password',
+        secureTextEntry: true,
+        value: confirmPassword,
+        onChangeText: text => {
+          setConfirmPassword(text);
+          if (registerAccountErrors.confirmPassword) setRegisterAccountErrors(e => ({ ...e, confirmPassword: undefined }));
+        },
+        onBlur: () => {
+          if (!confirmPassword) setRegisterAccountErrors(e => ({ ...e, confirmPassword: 'Please confirm your password.' }));
+          else if (password !== confirmPassword) setRegisterAccountErrors(e => ({ ...e, confirmPassword: 'Passwords do not match.' }));
+          else setRegisterAccountErrors(e => ({ ...e, confirmPassword: undefined }));
+        },
+        error: registerAccountErrors.confirmPassword,
+      })}
+      <Pressable
+        style={[styles.primaryButton, loading && styles.disabled]}
+        onPress={() => {
+          if (validateAccountStep()) setRegisterStep(1);
+        }}
+        disabled={loading}
+      >
+        {loading ? <ActivityIndicator color={colors.card} /> : <Text style={styles.primaryButtonText}>Next</Text>}
+      </Pressable>
+    </>
+  );
 
-        {isRegister && registerStep === 1 && (
-          <>
-            <TextInput
-              style={[styles.input, focusedInput === 'name' && styles.inputFocused, registerPersonalErrors.name && styles.inputError]}
-              placeholder="Full Name"
-              value={name}
-              onChangeText={text => {
-                setName(text);
-                if (registerPersonalErrors.name) setRegisterPersonalErrors(e => ({ ...e, name: undefined }));
-              }}
-              onFocus={() => setFocusedInput('name')}
-              onBlur={() => {
-                setFocusedInput(null);
-                if (!name.trim()) setRegisterPersonalErrors(e => ({ ...e, name: 'Full name is required.' }));
-                else setRegisterPersonalErrors(e => ({ ...e, name: undefined }));
-              }}
-            />
-            {registerPersonalErrors.name ? <Text style={styles.errorText}>{registerPersonalErrors.name}</Text> : null}
-            <TextInput
-              style={[styles.input, focusedInput === 'phone' && styles.inputFocused, registerPersonalErrors.phone && styles.inputError]}
-              placeholder="Phone"
-              value={phone}
-              onChangeText={text => {
-                setPhone(text);
-                if (registerPersonalErrors.phone) setRegisterPersonalErrors(e => ({ ...e, phone: undefined }));
-              }}
-              keyboardType="phone-pad"
-              onFocus={() => setFocusedInput('phone')}
-              onBlur={() => {
-                setFocusedInput(null);
-                if (phone && !/^\d{7,}$/.test(phone)) setRegisterPersonalErrors(e => ({ ...e, phone: 'Please enter a valid phone number (at least 7 digits).' }));
-                else setRegisterPersonalErrors(e => ({ ...e, phone: undefined }));
-              }}
-            />
-            {registerPersonalErrors.phone ? <Text style={styles.errorText}>{registerPersonalErrors.phone}</Text> : null}
-            <TextInput
-              style={[styles.input, focusedInput === 'dob' && styles.inputFocused, registerPersonalErrors.dateOfBirth && styles.inputError]}
-              placeholder="Date of Birth (YYYY-MM-DD)"
-              value={dateOfBirth}
-              onChangeText={text => {
-                setDateOfBirth(text);
-                if (registerPersonalErrors.dateOfBirth) setRegisterPersonalErrors(e => ({ ...e, dateOfBirth: undefined }));
-              }}
-              onFocus={() => setFocusedInput('dob')}
-              onBlur={() => {
-                setFocusedInput(null);
-                if (dateOfBirth && !/^\d{4}-\d{2}-\d{2}$/.test(dateOfBirth)) setRegisterPersonalErrors(e => ({ ...e, dateOfBirth: 'Date of Birth must be in YYYY-MM-DD format.' }));
-                else setRegisterPersonalErrors(e => ({ ...e, dateOfBirth: undefined }));
-              }}
-            />
-            {registerPersonalErrors.dateOfBirth ? <Text style={styles.errorText}>{registerPersonalErrors.dateOfBirth}</Text> : null}
+  const renderPersonalStep = () => (
+    <>
+      {renderInput({
+        id: 'register-name',
+        placeholder: 'Full Name',
+        value: name,
+        onChangeText: text => {
+          setName(text);
+          if (registerPersonalErrors.name) setRegisterPersonalErrors(e => ({ ...e, name: undefined }));
+        },
+        onBlur: () => {
+          if (!name.trim()) setRegisterPersonalErrors(e => ({ ...e, name: 'Full name is required.' }));
+          else setRegisterPersonalErrors(e => ({ ...e, name: undefined }));
+        },
+        error: registerPersonalErrors.name,
+      })}
+      {renderInput({
+        id: 'register-phone',
+        placeholder: 'Phone Number',
+        keyboardType: 'phone-pad',
+        value: phone,
+        onChangeText: text => {
+          setPhone(text);
+          if (registerPersonalErrors.phone) setRegisterPersonalErrors(e => ({ ...e, phone: undefined }));
+        },
+        onBlur: () => {
+          if (phone && !/^\d{7,}$/.test(phone)) setRegisterPersonalErrors(e => ({ ...e, phone: 'Please enter a valid phone number (at least 7 digits).' }));
+          else setRegisterPersonalErrors(e => ({ ...e, phone: undefined }));
+        },
+        error: registerPersonalErrors.phone,
+      })}
+      {renderInput({
+        id: 'register-dob',
+        placeholder: 'Date of Birth (YYYY-MM-DD)',
+        keyboardType: 'numbers-and-punctuation',
+        value: dateOfBirth,
+        onChangeText: text => {
+          setDateOfBirth(text);
+          if (registerPersonalErrors.dateOfBirth) setRegisterPersonalErrors(e => ({ ...e, dateOfBirth: undefined }));
+        },
+        onBlur: () => {
+          if (dateOfBirth && !/^\d{4}-\d{2}-\d{2}$/.test(dateOfBirth))
+            setRegisterPersonalErrors(e => ({ ...e, dateOfBirth: 'Date of Birth must be in YYYY-MM-DD format.' }));
+          else setRegisterPersonalErrors(e => ({ ...e, dateOfBirth: undefined }));
+        },
+        error: registerPersonalErrors.dateOfBirth,
+      })}
 
+      <View style={styles.sectionHeader}>
+        <Text style={styles.sectionTitle}>Health basics</Text>
+        {healthErrors.bloodType ? <Text style={styles.errorText}>{healthErrors.bloodType}</Text> : null}
+      </View>
+      <BloodTypePicker value={bloodType} onChange={setBloodType} />
+      {bloodType === 'custom' && renderInput({
+        id: 'register-blood-custom',
+        placeholder: 'Custom Blood Type',
+        value: customBloodType,
+        onChangeText: text => setCustomBloodType(text),
+        onBlur: () => {
+          const bt = customBloodType.trim();
+          if (bt && !/^A[+-]$|^B[+-]$|^AB[+-]$|^O[+-]$/.test(bt))
+            setHealthErrors(e => ({ ...e, bloodType: 'Blood type must be A+, A-, B+, B-, AB+, AB-, O+, or O-.' }));
+          else setHealthErrors(e => ({ ...e, bloodType: undefined }));
+        },
+        error: healthErrors.bloodType,
+      })}
 
-            {/* Blood Type Dropdown (cross-platform) */}
-            <Text style={{ fontWeight: 'bold', marginTop: 8 }}>Blood Type</Text>
-            <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 8 }}>
-              <BloodTypePicker value={bloodType} onChange={setBloodType} />
-              {bloodType === 'custom' && (
-                <TextInput
-                  style={[styles.input, { flex: 1, marginLeft: 8 }]}
-                  placeholder="Enter blood type"
-                  value={customBloodType}
-                  onChangeText={setCustomBloodType}
-                />
-              )}
-            </View>
-            {healthErrors.bloodType && <Text style={styles.errorText}>{healthErrors.bloodType}</Text>}
-
-            {/* Allergies Chip Input */}
-            <Text style={{ fontWeight: 'bold', marginTop: 8 }}>Allergies</Text>
-            <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 8 }}>
-              <TextInput
-                style={[styles.input, { flex: 1 }]}
-                placeholder="Add allergy"
-                value={allergyInput}
-                onChangeText={setAllergyInput}
-                onSubmitEditing={() => {
-                  if (allergyInput.trim() && !allergies.includes(allergyInput.trim())) {
-                    setAllergies([...allergies, allergyInput.trim()]);
-                    setAllergyInput('');
-                  }
-                }}
-                returnKeyType="done"
-              />
-              <Pressable
-                style={{ marginLeft: 8, backgroundColor: colors.primary, borderRadius: 999, padding: 8 }}
-                onPress={() => {
-                  if (allergyInput.trim() && !allergies.includes(allergyInput.trim())) {
-                    setAllergies([...allergies, allergyInput.trim()]);
-                    setAllergyInput('');
-                  }
-                }}
-              >
-                <Text style={{ color: colors.card, fontWeight: 'bold', fontSize: 18 }}>+</Text>
-              </Pressable>
-            </View>
-            <View style={{ flexDirection: 'row', flexWrap: 'wrap', marginBottom: 4 }}>
-              {allergies.map((a, i) => (
-                <View key={a + i} style={{ flexDirection: 'row', alignItems: 'center', backgroundColor: '#E5E7EB', borderRadius: 999, paddingHorizontal: 12, paddingVertical: 4, marginRight: 6, marginBottom: 4 }}>
-                  <Text style={{ color: '#222', fontSize: 15, marginRight: 4 }}>{a}</Text>
-                  <Pressable onPress={() => setAllergies(allergies.filter((_, idx) => idx !== i))}>
-                    <Text style={{ color: '#EF4444', fontWeight: 'bold', fontSize: 18, marginLeft: 2 }}>×</Text>
-                  </Pressable>
-                </View>
-              ))}
-            </View>
-            {healthErrors.allergies && <Text style={styles.errorText}>{healthErrors.allergies}</Text>}
-
-            {/* Medical Conditions Chip Input */}
-            <Text style={{ fontWeight: 'bold', marginTop: 8 }}>Medical Conditions</Text>
-            <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 8 }}>
-              <TextInput
-                style={[styles.input, { flex: 1 }]}
-                placeholder="Add condition"
-                value={conditionInput}
-                onChangeText={setConditionInput}
-                onSubmitEditing={() => {
-                  if (conditionInput.trim() && !medicalConditions.includes(conditionInput.trim())) {
-                    setMedicalConditions([...medicalConditions, conditionInput.trim()]);
-                    setConditionInput('');
-                  }
-                }}
-                returnKeyType="done"
-              />
-              <Pressable
-                style={{ marginLeft: 8, backgroundColor: colors.primary, borderRadius: 999, padding: 8 }}
-                onPress={() => {
-                  if (conditionInput.trim() && !medicalConditions.includes(conditionInput.trim())) {
-                    setMedicalConditions([...medicalConditions, conditionInput.trim()]);
-                    setConditionInput('');
-                  }
-                }}
-              >
-                <Text style={{ color: colors.card, fontWeight: 'bold', fontSize: 18 }}>+</Text>
-              </Pressable>
-            </View>
-            <View style={{ flexDirection: 'row', flexWrap: 'wrap', marginBottom: 4 }}>
-              {medicalConditions.map((c, i) => (
-                <View key={c + i} style={{ flexDirection: 'row', alignItems: 'center', backgroundColor: '#E5E7EB', borderRadius: 999, paddingHorizontal: 12, paddingVertical: 4, marginRight: 6, marginBottom: 4 }}>
-                  <Text style={{ color: '#222', fontSize: 15, marginRight: 4 }}>{c}</Text>
-                  <Pressable onPress={() => setMedicalConditions(medicalConditions.filter((_, idx) => idx !== i))}>
-                    <Text style={{ color: '#EF4444', fontWeight: 'bold', fontSize: 18, marginLeft: 2 }}>×</Text>
-                  </Pressable>
-                </View>
-              ))}
-            </View>
-            {healthErrors.conditions && <Text style={styles.errorText}>{healthErrors.conditions}</Text>}
-
-            <View style={styles.buttonRow}>
-              <Pressable
-                style={[styles.buttonSecondary, loading && { opacity: 0.7 }]}
-                onPress={() => setRegisterStep(0)}
-                disabled={loading}
-              >
-                <Text style={styles.buttonSecondaryText}>Back</Text>
-              </Pressable>
-              <Pressable
-                style={[styles.button, { flex: 1, marginLeft: 8 }, loading && { opacity: 0.7 }]}
-                onPress={() => {
-                  if (validatePersonalStep()) handleRegister();
-                }}
-                disabled={loading}
-              >
-                {loading ? (
-                  <ActivityIndicator color="#fff" />
-                ) : (
-                  <Text style={styles.buttonText}>Register</Text>
-                )}
-              </Pressable>
-            </View>
-          </>
-        )}
-
+      <View style={styles.chipRow}>
+        <TextInput
+          placeholder="Add allergy"
+          value={allergyInput}
+          onChangeText={setAllergyInput}
+          style={[styles.input, { flex: 1 }]}
+          placeholderTextColor={colors.muted}
+        />
         <Pressable
+          style={styles.addChip}
           onPress={() => {
-            setIsRegister(r => !r);
-            setRegisterStep(0);
+            if (!allergyInput.trim()) return;
+            setAllergies(prev => [...prev, allergyInput.trim()]);
+            setAllergyInput('');
+            setHealthErrors(e => ({ ...e, allergies: undefined }));
           }}
         >
-          <Text style={styles.link}>
-            {isRegister
-              ? 'Already have an account? Login'
-              : "Don't have an account? Register"}
-          </Text>
+          <Ionicons name="add" size={18} color={colors.primary} />
         </Pressable>
       </View>
-    </View>
+      {healthErrors.allergies ? <Text style={styles.errorText}>{healthErrors.allergies}</Text> : null}
+      <View style={styles.tagList}>
+        {allergies.map((a, idx) => (
+          <Pressable key={`${a}-${idx}`} onPress={() => setAllergies(prev => prev.filter((_, i) => i !== idx))} style={styles.tag}>
+            <Text style={styles.tagText}>{a}</Text>
+            <Ionicons name="close" size={16} color={colors.primary} />
+          </Pressable>
+        ))}
+      </View>
+
+      <View style={styles.chipRow}>
+        <TextInput
+          placeholder="Add condition"
+          value={conditionInput}
+          onChangeText={setConditionInput}
+          style={[styles.input, { flex: 1 }]}
+          placeholderTextColor={colors.muted}
+        />
+        <Pressable
+          style={styles.addChip}
+          onPress={() => {
+            if (!conditionInput.trim()) return;
+            setMedicalConditions(prev => [...prev, conditionInput.trim()]);
+            setConditionInput('');
+            setHealthErrors(e => ({ ...e, conditions: undefined }));
+          }}
+        >
+          <Ionicons name="add" size={18} color={colors.primary} />
+        </Pressable>
+      </View>
+      {healthErrors.conditions ? <Text style={styles.errorText}>{healthErrors.conditions}</Text> : null}
+      <View style={styles.tagList}>
+        {medicalConditions.map((c, idx) => (
+          <Pressable key={`${c}-${idx}`} onPress={() => setMedicalConditions(prev => prev.filter((_, i) => i !== idx))} style={styles.tag}>
+            <Text style={styles.tagText}>{c}</Text>
+            <Ionicons name="close" size={16} color={colors.primary} />
+          </Pressable>
+        ))}
+      </View>
+
+      <Pressable style={[styles.primaryButton, loading && styles.disabled]} onPress={handleRegister} disabled={loading}>
+        {loading ? <ActivityIndicator color={colors.card} /> : <Text style={styles.primaryButtonText}>Create account</Text>}
+      </Pressable>
+    </>
+  );
+
+  return (
+    <ScreenContainer
+      scrollable
+      withPadding={false}
+      contentContainerStyle={styles.container}
+    >
+      <LinearGradient
+        colors={colors.primaryGradient}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+        style={styles.hero}
+      >
+        <Image source={require('../assets/logo.png')} style={styles.logo} />
+        <Text style={styles.heroTitle}>{isRegister ? 'Create your medical ID' : 'Welcome back'}</Text>
+        <Text style={styles.heroSubtitle}>
+          {isRegister ? 'Join MedLink to keep your medical essentials in one place.' : 'Sign in to continue your connected care journey.'}
+        </Text>
+        <SegmentedControl
+          options={['Login', 'Register']}
+          value={isRegister ? 'Register' : 'Login'}
+          onChange={value => {
+            const register = value === 'Register';
+            setIsRegister(register);
+            if (!register) setRegisterStep(0);
+          }}
+        />
+      </LinearGradient>
+
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        style={{ width: '100%' }}
+      >
+        <View style={styles.formWrapper}>
+          <Card style={styles.cardSurface}>
+            {isRegister ? (
+              <>
+                <View style={styles.stepper}>
+                  {STEPS.map((step, index) => (
+                    <View key={step.key} style={styles.stepItem}>
+                      <View style={[styles.stepCircle, registerStep >= step.key && styles.stepCircleActive]}>
+                        <Text style={styles.stepNumber}>{index + 1}</Text>
+                      </View>
+                      <Text style={[styles.stepLabel, registerStep === step.key && styles.stepLabelActive]}>
+                        {step.label}
+                      </Text>
+                      {index < STEPS.length - 1 ? (
+                        <View style={[styles.stepDivider, registerStep > step.key && styles.stepDividerActive]} />
+                      ) : null}
+                    </View>
+                  ))}
+                </View>
+                <View style={{ gap: spacing.md }}>
+                  {registerStep === 0 ? renderAccountStep() : renderPersonalStep()}
+                </View>
+                {registerStep === 1 ? (
+                  <Pressable style={styles.secondaryButton} onPress={() => setRegisterStep(0)}>
+                    <Text style={styles.secondaryText}>Back</Text>
+                  </Pressable>
+                ) : null}
+              </>
+            ) : (
+              <View style={{ gap: spacing.md }}>{renderLogin()}</View>
+            )}
+          </Card>
+        </View>
+      </KeyboardAvoidingView>
+
+      <View style={styles.footerHint}>
+        <Text style={styles.footerText}>
+          By continuing you agree to our <Text style={styles.footerLink}>Terms</Text> and <Text style={styles.footerLink}>Privacy Policy</Text>.
+        </Text>
+      </View>
+
+      {showForgot && (
+        <View style={styles.modalOverlay}>
+          <Card style={styles.modalCard}>
+            <View style={{ alignItems: 'center', gap: spacing.sm }}>
+              <View style={styles.modalIconWrap}>
+                <Ionicons name="lock-closed" size={28} color={colors.primary} />
+              </View>
+              <Text style={styles.modalTitle}>Reset password</Text>
+              <Text style={styles.modalSubtitle}>
+                Enter your email address and we'll send you a password reset link.
+              </Text>
+            </View>
+            {renderInput({
+              id: 'forgot-email',
+              placeholder: 'Email',
+              autoCapitalize: 'none',
+              keyboardType: 'email-address',
+              value: forgotEmail,
+              onChangeText: setForgotEmail,
+            })}
+            <View style={styles.modalActions}>
+              <Pressable
+                style={styles.secondaryButton}
+                onPress={() => {
+                  setShowForgot(false);
+                  setForgotEmail('');
+                }}
+              >
+                <Text style={styles.secondaryText}>Cancel</Text>
+              </Pressable>
+              <Pressable
+                style={[styles.primaryButton, styles.modalPrimary]}
+                onPress={async () => {
+                  if (!forgotEmail || !emailRegex.test(forgotEmail)) {
+                    Alert.alert('Invalid Email', 'Please enter a valid email address.');
+                    return;
+                  }
+                  setForgotLoading(true);
+                  try {
+                    await sendPasswordResetEmail(auth, forgotEmail);
+                    Alert.alert('Password Reset', 'A password reset link has been sent to your email.');
+                    setShowForgot(false);
+                    setForgotEmail('');
+                  } catch (e: any) {
+                    Alert.alert('Error', e.message || 'Failed to send reset email.');
+                  } finally {
+                    setForgotLoading(false);
+                  }
+                }}
+                disabled={forgotLoading}
+              >
+                {forgotLoading ? <ActivityIndicator color={colors.card} /> : <Text style={styles.primaryButtonText}>Send link</Text>}
+              </Pressable>
+            </View>
+          </Card>
+        </View>
+      )}
+    </ScreenContainer>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: colors.bg,
-    padding: spacing.xl,
+    flexGrow: 1,
+    paddingBottom: spacing.xxl,
   },
-  card: {
-    width: '100%',
-    maxWidth: 370,
-    backgroundColor: colors.card,
-    borderRadius: 16,
-    padding: spacing.xl,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.10,
-    shadowRadius: 12,
-    elevation: 4,
+  hero: {
+    paddingTop: spacing.xxl * 1.4,
+    paddingBottom: spacing.xxl,
+    paddingHorizontal: spacing.xl,
+    borderBottomLeftRadius: radius.xl + 6,
+    borderBottomRightRadius: radius.xl + 6,
     alignItems: 'center',
+    gap: spacing.md,
+  },
+  logo: {
+    width: 96,
+    height: 96,
+    resizeMode: 'contain',
+  },
+  heroTitle: {
+    ...type.h1,
+    color: '#fff',
+  },
+  heroSubtitle: {
+    color: 'rgba(255,255,255,0.8)',
+    textAlign: 'center',
+    lineHeight: 20,
+  },
+  formWrapper: {
+    marginTop: -spacing.xxl * 0.7,
+    paddingHorizontal: spacing.xl,
+  },
+  cardSurface: {
+    paddingVertical: spacing.xxl,
+    paddingHorizontal: spacing.xl,
+    gap: spacing.lg,
   },
   input: {
     width: '100%',
-    maxWidth: 320,
-    borderWidth: 1,
-    borderColor: colors.line,
-    borderRadius: 8,
-    padding: spacing.md,
-    marginVertical: spacing.md,
-    backgroundColor: colors.card,
+    backgroundColor: 'rgba(255,255,255,0.85)',
+    borderRadius: radius.md,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: 14,
     fontSize: 16,
+    color: colors.text,
+    borderWidth: 1,
+    borderColor: 'rgba(37,99,235,0.15)',
   },
   inputFocused: {
     borderColor: colors.primary,
     shadowColor: colors.primary,
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.10,
-    shadowRadius: 4,
+    shadowOpacity: 0.15,
+    shadowRadius: 10,
+    shadowOffset: { width: 0, height: 6 },
   },
   inputError: {
-    borderColor: '#e53935',
+    borderColor: colors.danger,
   },
   errorText: {
-    color: '#e53935',
+    color: colors.danger,
     fontSize: 13,
-    marginTop: -10,
-    marginBottom: 8,
-    alignSelf: 'flex-start',
-    maxWidth: 320,
+    marginTop: 6,
+  },
+  forgotLink: {
+    alignSelf: 'flex-end',
+  },
+  forgotText: {
+    color: colors.primary,
+    fontWeight: '600',
+  },
+  primaryButton: {
+    backgroundColor: colors.primary,
+    borderRadius: radius.md,
+    paddingVertical: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexDirection: 'row',
+    gap: spacing.sm,
+    ...Platform.select({
+      ios: {
+        shadowColor: colors.primary,
+        shadowOpacity: 0.2,
+        shadowRadius: 12,
+        shadowOffset: { width: 0, height: 8 },
+      },
+      android: {
+        elevation: 4,
+      },
+    }),
+  },
+  primaryButtonText: {
+    color: colors.card,
+    fontWeight: '700',
+    fontSize: 16,
+  },
+  disabled: {
+    opacity: 0.7,
+  },
+  secondaryButton: {
+    borderWidth: 1,
+    borderColor: colors.line,
+    borderRadius: radius.md,
+    paddingVertical: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  secondaryText: {
+    color: colors.muted,
+    fontWeight: '600',
+  },
+  sectionHeader: {
+    marginTop: spacing.lg,
+    marginBottom: spacing.xs,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  sectionTitle: {
+    fontWeight: '600',
+    color: colors.text,
+  },
+  chipRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  addChip: {
+    width: 42,
+    height: 42,
+    borderRadius: radius.md,
+    backgroundColor: colors.chipBg,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  tagList: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.xs,
+  },
+  tag: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    backgroundColor: colors.chipBg,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.xs,
+    borderRadius: radius.pill,
+  },
+  tagText: {
+    color: colors.chipText,
+    fontWeight: '600',
   },
   stepper: {
     flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: spacing.lg,
-    width: '100%',
-    maxWidth: 320,
     justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: spacing.sm,
+    borderRadius: radius.lg,
+    backgroundColor: 'rgba(37,99,235,0.08)',
   },
-  stepWrapper: {
+  stepItem: {
+    flex: 1,
     alignItems: 'center',
   },
   stepCircle: {
-    width: 24,
-    height: 24,
-    borderRadius: 12,
+    width: 36,
+    height: 36,
+    borderRadius: 18,
     borderWidth: 1,
-    borderColor: colors.line,
-    justifyContent: 'center',
+    borderColor: 'rgba(37,99,235,0.4)',
     alignItems: 'center',
-    backgroundColor: colors.card,
+    justifyContent: 'center',
+    backgroundColor: 'rgba(255,255,255,0.7)',
   },
   stepCircleActive: {
     backgroundColor: colors.primary,
     borderColor: colors.primary,
   },
   stepNumber: {
-    color: colors.text,
-    fontSize: 12,
+    color: colors.primary,
+    fontWeight: '700',
   },
   stepLabel: {
-    marginTop: 4,
-    fontSize: 12,
-    color: colors.text,
+    marginTop: 8,
+    color: colors.muted,
+    fontSize: 13,
+    fontWeight: '600',
   },
   stepLabelActive: {
-    fontWeight: 'bold',
     color: colors.primary,
   },
-  stepLine: {
-    flex: 1,
-    height: 1,
-    backgroundColor: colors.line,
-    marginHorizontal: 8,
+  stepDivider: {
+    position: 'absolute',
+    top: 18,
+    right: -spacing.md,
+    height: 2,
+    width: '100%',
+    backgroundColor: 'rgba(37,99,235,0.2)',
   },
-  stepLineActive: {
+  stepDividerActive: {
     backgroundColor: colors.primary,
   },
-  button: {
-    backgroundColor: colors.primary,
-    paddingVertical: spacing.md,
+  footerHint: {
+    marginTop: spacing.xl,
     paddingHorizontal: spacing.xl,
-    borderRadius: 8,
-    marginTop: spacing.lg,
-    width: '100%',
-    maxWidth: 320,
+  },
+  footerText: {
+    color: colors.muted,
+    textAlign: 'center',
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  footerLink: {
+    color: colors.primary,
+    fontWeight: '600',
+  },
+  modalOverlay: {
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+    left: 0,
+    right: 0,
+    backgroundColor: 'rgba(15,23,42,0.35)',
+    justifyContent: 'center',
     alignItems: 'center',
+    padding: spacing.xl,
   },
-  buttonRow: {
-    flexDirection: 'row',
+  modalCard: {
     width: '100%',
-    maxWidth: 320,
-    marginTop: spacing.lg,
+    maxWidth: 380,
+    gap: spacing.lg,
   },
-  buttonSecondary: {
-    flex: 1,
-    backgroundColor: colors.card,
-    paddingVertical: spacing.md,
-    paddingHorizontal: spacing.xl,
-    borderRadius: 8,
-    borderWidth: 1,
-    borderColor: colors.line,
+  modalIconWrap: {
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    backgroundColor: 'rgba(37,99,235,0.12)',
     alignItems: 'center',
-    marginRight: 8,
+    justifyContent: 'center',
   },
-  buttonSecondaryText: {
+  modalTitle: {
+    fontSize: 20,
+    fontWeight: '700',
     color: colors.text,
-    fontWeight: 'bold',
-    fontSize: 18,
   },
-  buttonText: {
-  color: colors.card,
-    fontWeight: 'bold',
-    fontSize: 18,
+  modalSubtitle: {
+    color: colors.muted,
+    textAlign: 'center',
+    lineHeight: 18,
   },
-  link: {
-    color: colors.primary,
-    marginTop: spacing.lg,
-    textDecorationLine: 'underline',
+  modalActions: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+  },
+  modalPrimary: {
+    flex: 1,
   },
 });

--- a/src/screens/Reminders.tsx
+++ b/src/screens/Reminders.tsx
@@ -1,8 +1,8 @@
 
 import React, { useEffect, useState } from 'react';
-import { View, Text, ScrollView, StyleSheet, Pressable, Switch, ActivityIndicator, Modal, TextInput, Platform } from 'react-native';
+import { View, Text, StyleSheet, Pressable, Switch, ActivityIndicator, Modal, TextInput } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
-import { colors, spacing, shadow } from '../theme';
+import { colors, spacing, shadow, radius } from '../theme';
 import { SegmentedControl } from '../components/SegmentedControl';
 import Card from '../components/Card';
 import { ListRow } from '../components/ListRow';
@@ -10,6 +10,7 @@ import { useReminders } from '../hooks/useReminders';
 import Chip from '../components/Chip';
 import CalendarStrip from '../components/CalendarStrip';
 import { getTodayStats, setCompleted, getDayCompletion } from '../core/completion';
+import ScreenContainer from '../components/ScreenContainer';
 
 export default function Reminders() {
   const [segment, setSegment] = useState('Active');
@@ -102,6 +103,8 @@ export default function Reminders() {
     }
   };
 
+  const completedCount = Object.values(doneMap).filter(Boolean).length;
+
   let content;
   if (loading) {
     content = <ActivityIndicator style={{ marginTop: spacing.xl }} color={colors.primary} />;
@@ -109,82 +112,81 @@ export default function Reminders() {
     content = <Text style={{ color: colors.danger, textAlign: 'center', marginTop: spacing.xl }}>{error}</Text>;
   } else {
     content = (
-      <ScrollView
-        contentContainerStyle={{
-          padding: spacing.xl,
-          paddingBottom: 96, // extra space for navbar and FAB
-        }}
-        keyboardShouldPersistTaps="handled"
-      >
-        {/* Calendar strip and quick filters */}
-        <View style={{ marginBottom: spacing.md }}>
-          <CalendarStrip value={selectedDate} onChange={setSelectedDate} />
-        </View>
-        <View style={{ flexDirection: 'row', gap: 8, marginBottom: spacing.md }}>
-          <Chip label="All" selected={segment === 'Active'} onPress={() => setSegment('Active')} />
-          <Chip label="Past" selected={segment === 'Past'} onPress={() => setSegment('Past')} />
-        </View>
+      <View style={styles.listContainer}>
         {filtered.length === 0 ? (
-          <Text style={{ textAlign: 'center', color: colors.muted }}>No reminders</Text>
+          <Text style={styles.emptyText}>No reminders</Text>
         ) : null}
         {filtered.map(r => (
-          <Card key={r.id} style={{ paddingVertical: spacing.lg }}>
+          <Card key={r.id} style={styles.reminderCard}>
             <ListRow
               title={r.title}
               subtitle={r.frequency ? `${r.datetime} • ${r.frequency}` : r.datetime}
               right={
-                <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+                <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
                   <Switch
                     value={r.active}
                     onValueChange={() => toggleActive(r)}
                     disabled={!!toggling[r.id]}
                   />
-                  {toggling[r.id] && <ActivityIndicator size={16} color={colors.primary} style={{ marginLeft: 6 }} />}
+                  {toggling[r.id] && <ActivityIndicator size={16} color={colors.primary} />}
                 </View>
               }
             />
             {r.description ? (
-              <Text style={{ color: colors.muted, marginLeft: 56, marginTop: 4 }}>{r.description}</Text>
+              <Text style={styles.description}>{r.description}</Text>
             ) : null}
-            {/* Done today pill button */}
-            <View style={{ flexDirection: 'row', marginLeft: 56, marginTop: 10 }}>
+            <View style={styles.actionsRow}>
               <Pressable
                 onPress={() => toggleDoneToday(r.id)}
-                style={{
-                  backgroundColor: doneMap[r.id] ? colors.primary : colors.card,
-                  borderWidth: 1,
-                  borderColor: doneMap[r.id] ? colors.primary : colors.line,
-                  paddingVertical: 8,
-                  paddingHorizontal: 12,
-                  borderRadius: 999,
-                }}
+                style={[styles.doneButton, doneMap[r.id] && styles.doneButtonActive]}
               >
-                <Text style={{ color: doneMap[r.id] ? colors.card : colors.text, fontWeight: '600' }}>
+                <Text style={[styles.doneButtonText, doneMap[r.id] && styles.doneButtonTextActive]}>
                   {doneMap[r.id] ? 'Done today' : 'Mark done today'}
                 </Text>
               </Pressable>
             </View>
             {!!toggleMsg[r.id] && (
-              <Text style={{ color: toggleMsg[r.id].includes('Failed') ? colors.danger : colors.primary, marginLeft: 56, marginTop: 2, fontSize: 13 }}>{toggleMsg[r.id]}</Text>
+              <Text style={[styles.statusText, toggleMsg[r.id].includes('Failed') && styles.statusTextError]}>{toggleMsg[r.id]}</Text>
             )}
           </Card>
         ))}
-      </ScrollView>
+      </View>
     );
   }
 
   return (
-  <View style={{ flex: 1, backgroundColor: colors.bg, paddingBottom: 80 }}>
-      <View style={{ padding: spacing.xl }}>
+    <ScreenContainer scrollable contentContainerStyle={styles.content}>
+      <Card style={styles.headerCard}>
         <SegmentedControl options={['Active', 'Past']} value={segment} onChange={setSegment} />
-      </View>
+        <View style={styles.calendarWrap}>
+          <CalendarStrip value={selectedDate} onChange={setSelectedDate} />
+        </View>
+        <View style={styles.filterRow}>
+          <Chip label="Active" selected={segment === 'Active'} onPress={() => setSegment('Active')} />
+          <Chip label="Past" selected={segment === 'Past'} onPress={() => setSegment('Past')} />
+        </View>
+        <View style={styles.summaryRow}>
+          <View>
+            <Text style={styles.summaryLabel}>Reminders today</Text>
+            <Text style={styles.summaryValue}>{filtered.length}</Text>
+          </View>
+          <View>
+            <Text style={styles.summaryLabel}>Completed</Text>
+            <Text style={styles.summaryValue}>{completedCount}</Text>
+          </View>
+        </View>
+      </Card>
+
       {content}
-      <Pressable style={styles.fab} android_ripple={{ color: colors.primary600 }} onPress={() => setModalVisible(true)}>
-        <Ionicons name="add" size={28} color="#fff" />
+
+      <Pressable style={styles.addButton} android_ripple={{ color: colors.primary600 }} onPress={() => setModalVisible(true)}>
+        <Ionicons name="add" size={22} color="#fff" />
+        <Text style={styles.addButtonText}>Add reminder</Text>
       </Pressable>
+
       <Modal
         visible={modalVisible}
-        animationType="slide"
+        animationType="fade"
         transparent={true}
         onRequestClose={() => setModalVisible(false)}
       >
@@ -260,50 +262,107 @@ export default function Reminders() {
           </View>
         </View>
       </Modal>
-    </View>
+    </ScreenContainer>
   );
 }
 
 const styles = StyleSheet.create({
-  fab: {
-    position: 'absolute',
-    right: spacing.xl,
-    bottom: spacing.xl,
+  content: {
+    gap: spacing.xl,
+    paddingBottom: spacing.xxl,
+  },
+  headerCard: {
+    gap: spacing.md,
+  },
+  calendarWrap: {
+    marginTop: spacing.sm,
+  },
+  filterRow: {
+    flexDirection: 'row',
+    gap: 10,
+  },
+  summaryRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginTop: spacing.md,
+  },
+  summaryLabel: { color: colors.muted, fontSize: 13 },
+  summaryValue: { color: colors.text, fontWeight: '700', fontSize: 20, marginTop: 4 },
+  listContainer: {
+    gap: spacing.md,
+  },
+  emptyText: {
+    textAlign: 'center',
+    color: colors.muted,
+    marginTop: spacing.lg,
+  },
+  reminderCard: {
+    gap: spacing.sm,
+  },
+  description: {
+    color: colors.muted,
+    marginLeft: spacing.lg,
+  },
+  actionsRow: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    marginTop: spacing.sm,
+  },
+  doneButton: {
+    borderRadius: radius.pill,
+    borderWidth: 1,
+    borderColor: colors.line,
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+    backgroundColor: colors.glass,
+  },
+  doneButtonActive: {
     backgroundColor: colors.primary,
-    width: 56,
-    height: 56,
-    borderRadius: 28,
+    borderColor: colors.primary,
+  },
+  doneButtonText: { color: colors.text, fontWeight: '600' },
+  doneButtonTextActive: { color: '#fff' },
+  statusText: { marginTop: 6, color: colors.primary, fontSize: 13 },
+  statusTextError: { color: colors.danger },
+  addButton: {
+    flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
+    alignSelf: 'center',
+    gap: 8,
+    backgroundColor: colors.primary,
+    paddingVertical: 14,
+    paddingHorizontal: spacing.xl,
+    borderRadius: radius.pill,
     ...shadow.card,
-    zIndex: 10,
   },
+  addButtonText: { color: '#fff', fontWeight: '700', fontSize: 15 },
   modalOverlay: {
     flex: 1,
-  backgroundColor: colors.overlay,
+    backgroundColor: colors.overlay,
     justifyContent: 'center',
     alignItems: 'center',
   },
   modalContent: {
-    backgroundColor: colors.bg,
+    backgroundColor: colors.glass,
     padding: spacing.xl,
-    borderRadius: 16,
+    borderRadius: radius.xl,
     width: '90%',
-    maxWidth: 400,
+    maxWidth: 420,
     ...shadow.card,
   },
   input: {
     borderWidth: 1,
     borderColor: colors.line,
-    borderRadius: 8,
-    padding: Platform.OS === 'web' ? 12 : spacing.md,
+    borderRadius: radius.md,
+    padding: spacing.md,
     marginBottom: spacing.sm,
-    backgroundColor: colors.card,
+    backgroundColor: colors.surface,
     fontSize: 16,
   },
   modalBtn: {
     paddingVertical: spacing.md,
-    borderRadius: 8,
+    borderRadius: radius.md,
     alignItems: 'center',
     justifyContent: 'center',
   },

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -2,15 +2,11 @@ import React, { useEffect, useState } from 'react'
 import { View, Text, Switch, StyleSheet } from 'react-native'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { colors, spacing } from '../theme'
+import ScreenContainer from '../components/ScreenContainer'
+import Card from '../components/Card'
 
 const TELEMETRY_KEY = 'settings_telemetry_enabled_v1'
 const HAPTICS_KEY = 'settings_haptics_enabled_v1'
-
-const styles = StyleSheet.create({
-  container: { flex: 1, padding: spacing.lg, backgroundColor: colors.bg },
-  row: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', paddingVertical: 12 },
-  label: { color: colors.text, fontSize: 16 }
-})
 
 export default function Settings() {
   const [telemetry, setTelemetry] = useState(true)
@@ -41,9 +37,47 @@ export default function Settings() {
   }
 
   return (
-    <View style={styles.container}>
-      <View style={styles.row}><Text style={styles.label}>Send anonymous telemetry</Text><Switch value={telemetry} onValueChange={setTelemetryToggle} /></View>
-      <View style={styles.row}><Text style={styles.label}>Enable haptics on scan success</Text><Switch value={haptics} onValueChange={setHapticsToggle} /></View>
-    </View>
+    <ScreenContainer contentContainerStyle={styles.content}>
+      <Card style={styles.card}>
+        <View style={styles.row}>
+          <View style={styles.textBlock}>
+            <Text style={styles.label}>Send anonymous telemetry</Text>
+            <Text style={styles.description}>Share usage insights to help us improve.</Text>
+          </View>
+          <Switch value={telemetry} onValueChange={setTelemetryToggle} />
+        </View>
+      </Card>
+      <Card style={styles.card}>
+        <View style={styles.row}>
+          <View style={styles.textBlock}>
+            <Text style={styles.label}>Enable haptics</Text>
+            <Text style={styles.description}>Vibrate when scans complete successfully.</Text>
+          </View>
+          <Switch value={haptics} onValueChange={setHapticsToggle} />
+        </View>
+      </Card>
+    </ScreenContainer>
   )
 }
+
+const styles = StyleSheet.create({
+  content: {
+    gap: spacing.xl,
+    paddingBottom: spacing.xxl,
+  },
+  card: {
+    gap: spacing.sm,
+  },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    gap: spacing.md,
+  },
+  textBlock: {
+    flex: 1,
+    gap: 6,
+  },
+  label: { color: colors.text, fontSize: 16, fontWeight: '600' },
+  description: { color: colors.muted, fontSize: 13 },
+})

--- a/src/screens/UserProfile.tsx
+++ b/src/screens/UserProfile.tsx
@@ -1,219 +1,254 @@
 import React, { useEffect, useState, useRef } from 'react';
-import SkeletonImage from '../components/SkeletonImage';
-import { ScrollView, View, Text, StyleSheet, Pressable, Modal, Alert, ActivityIndicator, Platform, useWindowDimensions, Image as RNImage } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import {
+  View,
+  Text,
+  StyleSheet,
+  Pressable,
+  Modal,
+  Alert,
+  ActivityIndicator,
+  Platform,
+  useWindowDimensions,
+  Image as RNImage,
+} from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
 import { useTranslation } from 'react-i18next';
 import { Ionicons } from '@expo/vector-icons';
 import { signOut } from 'firebase/auth';
-import { auth } from '../lib/firebase';
-import { fetchUserProfile, createOrUpdateUserProfile, Profile } from '../core/userProfile';
-import { useLoading } from '../hooks/LoadingContext';
-import { colors, spacing, type, radius } from '../theme';
+import SkeletonImage from '../components/SkeletonImage';
+import ScreenContainer from '../components/ScreenContainer';
 import Card from '../components/Card';
-// sheet components (extracted for clarity)
+import { ListRow } from '../components/ListRow';
+import { auth } from '../lib/firebase';
+import { fetchUserProfile, createOrUpdateUserProfile, type Profile } from '../core/userProfile';
+import { useLoading } from '../hooks/LoadingContext';
 import MedicationsSheet from './user-sheets/MedicationsSheet';
 import MedicalSheet from './user-sheets/MedicalSheet';
 import InsuranceSheet from './user-sheets/InsuranceSheet';
 import EmergencySheet from './user-sheets/EmergencySheet';
 import EditProfileSheet from './user-sheets/EditProfileSheet';
-import { ListRow } from '../components/ListRow';
-
-const styles = StyleSheet.create({
-  headerCard: {
-    alignItems: 'center',
-    paddingVertical: spacing.lg,
-  backgroundColor: colors.surface,
-    borderRadius: radius.lg,
-    // ...shadow.lg, // Removed invalid property
-    marginBottom: spacing.lg,
-  },
-  btn: {
-    flex: 1,
-    backgroundColor: colors.primary,
-    marginHorizontal: 4,
-    paddingVertical: 12,
-    borderRadius: 8,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  btnTxt: {
-  color: colors.surface,
-    fontWeight: 'bold',
-    fontSize: 16,
-  },
-  buttonRow: {
-    flexDirection: 'row',
-    gap: 8,
-    marginTop: spacing.lg,
-  },
-  avatar: {
-    width: 80,
-    height: 80,
-    borderRadius: 40,
-  backgroundColor: colors.line,
-  },
-  buttonGrid: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    justifyContent: 'space-between',
-    gap: 12,
-  },
-  buttonGridItem: {
-    flexBasis: '48%',
-    minWidth: 140,
-    marginBottom: 8,
-    borderRadius: 12,
-    paddingVertical: 14,
-    alignItems: 'center',
-    justifyContent: 'center',
-    elevation: 3,
-  },
-  primaryButton: {
-    backgroundColor: colors.primary,
-  },
-  signOutButton: {
-    backgroundColor: colors.danger,
-  },
-  buttonPressed: {
-    shadowOpacity: 0.18,
-    transform: [{ scale: 0.995 }],
-  },
-});
-
-const modalStyles = StyleSheet.create({
-  overlay: {
-  flex: 1,
-  backgroundColor: colors.overlay,
-  },
-  content: {
-  backgroundColor: colors.surface,
-    borderRadius: 16,
-    padding: 24,
-    width: '90%',
-    maxHeight: '90%',
-    alignSelf: 'center',
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.1,
-    shadowRadius: 8,
-    elevation: 5,
-  },
-  label: {
-    fontWeight: 'bold',
-    marginTop: 12,
-    marginBottom: 4,
-  color: colors.text,
-  },
-  input: {
-    borderWidth: 1,
-  borderColor: colors.line,
-    borderRadius: 8,
-    padding: 12,
-    marginBottom: 4,
-    fontSize: 16,
-  backgroundColor: colors.surface,
-  },
-  inputError: {
-  borderColor: colors.danger,
-  },
-  error: {
-  color: colors.danger,
-    fontSize: 13,
-    marginBottom: 4,
-  },
-  chipInputRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: 4,
-  },
-  chipInput: {
-    flex: 1,
-    borderWidth: 1,
-  borderColor: colors.line,
-  borderRadius: radius.md,
-  padding: 12,
-  backgroundColor: colors.surface,
-    fontSize: 16,
-  },
-  chipAddBtn: {
-  marginLeft: 8,
-  backgroundColor: colors.line,
-    borderRadius: 999,
-    paddingHorizontal: 12,
-    paddingVertical: 6,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  chipList: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    gap: 8,
-    marginBottom: 4,
-  },
-  chip: {
-    flexDirection: 'row',
-    alignItems: 'center',
-  backgroundColor: colors.line,
-    borderRadius: 999,
-    paddingHorizontal: 12,
-    paddingVertical: 4,
-    marginRight: 6,
-    marginBottom: 4,
-  },
-  chipText: {
-  color: colors.text,
-    fontSize: 15,
-    marginRight: 4,
-  },
-  chipRemove: {
-    color: colors.danger,
-    fontWeight: 'bold',
-    fontSize: 18,
-    marginLeft: 2,
-  },
-  btn: {
-    paddingVertical: 12,
-    borderRadius: 8,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-});
+import { colors, spacing, type, radius, shadow } from '../theme';
+import pkg from '../../package.json';
 
 type UserProfileProps = {
   navigation: any;
   onLogout?: () => void;
 };
 
+type ActionTone = 'primary' | 'neutral' | 'danger';
 
-import pkg from '../../package.json';
+type QuickAction = {
+  key: string;
+  label: string;
+  icon: React.ComponentProps<typeof Ionicons>['name'];
+  onPress: () => void;
+  tone?: ActionTone;
+};
+
+const heroAvatar = require('../assets/avatar-placeholder.png');
+
+const styles = StyleSheet.create({
+  loader: {
+    flex: 1,
+    backgroundColor: colors.bg,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  hero: {
+    borderBottomLeftRadius: radius.xl + 6,
+    borderBottomRightRadius: radius.xl + 6,
+    paddingTop: spacing.xxl * 1.4,
+    paddingBottom: spacing.xxl,
+    paddingHorizontal: spacing.xl,
+    gap: spacing.lg,
+  },
+  heroTop: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.lg,
+  },
+  heroName: {
+    ...type.h1,
+    color: '#fff',
+  },
+  heroMeta: {
+    color: 'rgba(255,255,255,0.78)',
+    marginTop: 2,
+  },
+  heroStats: {
+    flexDirection: 'row',
+    gap: spacing.lg,
+    flexWrap: 'wrap',
+  },
+  statPill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    backgroundColor: 'rgba(255,255,255,0.18)',
+    borderRadius: radius.pill,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.xs,
+  },
+  statText: {
+    color: '#fff',
+    fontWeight: '600',
+  },
+  quickActions: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.sm,
+  },
+  quickButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.xs,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+    borderRadius: radius.lg,
+    backgroundColor: 'rgba(255,255,255,0.16)',
+    minWidth: 150,
+  },
+  quickButtonText: {
+    color: '#fff',
+    fontWeight: '600',
+  },
+  quickButtonDanger: {
+    backgroundColor: 'rgba(239,68,68,0.18)',
+  },
+  content: {
+    paddingBottom: spacing.xxl,
+    gap: spacing.lg,
+  },
+  sectionCard: {
+    gap: spacing.sm,
+  },
+  sectionTitle: {
+    ...type.h2,
+  },
+  sectionHint: {
+    color: colors.muted,
+    marginBottom: spacing.sm,
+  },
+  listSpacer: {
+    height: 1,
+    backgroundColor: 'rgba(15,23,42,0.08)',
+    marginVertical: spacing.xs,
+  },
+  actionRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: spacing.md,
+  },
+  actionLabel: {
+    color: colors.text,
+    fontWeight: '600',
+  },
+  actionIcon: {
+    width: 36,
+    height: 36,
+    borderRadius: radius.md,
+    backgroundColor: colors.chipBg,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  version: {
+    textAlign: 'center',
+    color: colors.muted,
+    marginTop: spacing.md,
+  },
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(15,23,42,0.4)',
+    justifyContent: 'center',
+    paddingHorizontal: spacing.xl,
+  },
+  modalCard: {
+    paddingVertical: spacing.xxl,
+    paddingHorizontal: spacing.xl,
+    gap: spacing.md,
+  },
+  modalLangRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.sm,
+    borderRadius: radius.md,
+    backgroundColor: 'rgba(248,250,255,0.7)',
+  },
+  modalButtons: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+    marginTop: spacing.lg,
+  },
+  modalClose: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: spacing.md,
+    borderRadius: radius.md,
+    borderWidth: 1,
+    borderColor: colors.line,
+  },
+  modalCloseText: {
+    color: colors.muted,
+    fontWeight: '600',
+  },
+  modalConfirm: {
+    flex: 1,
+    backgroundColor: colors.primary,
+    borderRadius: radius.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: spacing.md,
+    ...shadow.soft,
+  },
+  modalConfirmText: {
+    color: colors.card,
+    fontWeight: '700',
+  },
+});
+
+const modalStyles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: colors.overlay,
+    justifyContent: 'center',
+    paddingHorizontal: spacing.xl,
+  },
+  content: {
+    borderRadius: radius.xl,
+    overflow: 'hidden',
+    ...shadow.card,
+  },
+});
 
 export default function UserProfile({ navigation, onLogout }: Readonly<UserProfileProps>) {
   const { t, i18n } = useTranslation();
   const { startLoading, finishLoading } = useLoading();
-  const _prefetched = useRef(new Set<string>());
   const { width } = useWindowDimensions();
-  const contentPadding = width > 700 ? 48 : spacing.xl;
-  const avatarSize = width > 700 ? 120 : 80;
+  const _prefetched = useRef(new Set<string>());
+  const avatarSize = width > 700 ? 120 : 88;
+
   const [langModal, setLangModal] = useState(false);
-  const [langRefresh, setLangRefresh] = useState(0);
+  const [profile, setProfile] = useState<Profile | null>(null);
+  const [loadingProfile, setLoadingProfile] = useState(true);
+  const [editModal, setEditModal] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [edit, setEdit] = useState<any>({});
+  const [medicalModal, setMedicalModal] = useState(false);
+  const [medicationsModal, setMedicationsModal] = useState(false);
+  const [insuranceModal, setInsuranceModal] = useState(false);
+  const [emergencyModal, setEmergencyModal] = useState(false);
+
   const languages = [
     { code: 'en', label: t('languages.english', 'English'), flag: require('../assets/gb.svg') },
     { code: 'fr', label: t('languages.french', 'French'), flag: require('../assets/fr.svg') },
     { code: 'ar', label: t('languages.arabic', 'Arabic'), flag: require('../assets/mr.svg') },
   ];
   const currentLang = languages.find(l => l.code === i18n.language) || languages[0];
-  const [profile, setProfile] = useState<Profile | null>(null);
-  const [loadingProfile, setLoadingProfile] = useState(true);
-  const [editModal, setEditModal] = useState(false);
-  const [saving, setSaving] = useState(false);
-  const [edit, setEdit] = useState<any>({});
-  // Emergency contacts errors (array of objects) - handled locally in validation
-  const [medicalModal, setMedicalModal] = useState(false);
-  const [medicationsModal, setMedicationsModal] = useState(false);
-  const [insuranceModal, setInsuranceModal] = useState(false);
-  const [emergencyModal, setEmergencyModal] = useState(false);
-
-  // chip/remove handlers are implemented inside EditProfileSheet
 
   const openEdit = () => {
     if (!profile) return;
@@ -241,20 +276,20 @@ export default function UserProfile({ navigation, onLogout }: Readonly<UserProfi
         {
           text: t('auth.signOut', 'Logout'),
           style: 'destructive',
-          onPress: () => { (async () => {
-            try {
-              await signOut(auth);
-              if (onLogout) onLogout();
-            } catch (error: any) {
-              Alert.alert(t('common.error', 'Error'), error.message || t('errors.logoutError', 'Failed to log out.'));
-            }
-          })(); },
+          onPress: () => {
+            (async () => {
+              try {
+                await signOut(auth);
+                if (onLogout) onLogout();
+              } catch (error: any) {
+                Alert.alert(t('common.error', 'Error'), error.message || t('errors.logoutError', 'Failed to log out.'));
+              }
+            })();
+          },
         },
-      ]
+      ],
     );
   };
-
-  // Validation and save are handled inside EditProfileSheet
 
   useEffect(() => {
     let mounted = true;
@@ -265,31 +300,33 @@ export default function UserProfile({ navigation, onLogout }: Readonly<UserProfi
         const userProfile = await fetchUserProfile();
         if (!mounted) return;
         setProfile(userProfile);
-        // If profile contains a remote avatar image, prefetch it
         const uri = (userProfile as any)?.image || (userProfile as any)?.avatar;
-          if (uri && !_prefetched.current.has(uri)) {
-            const imgKey = 'profile-image';
-            startLoading(imgKey);
-            try {
-              await RNImage.prefetch(uri);
-              _prefetched.current.add(uri);
-            } catch (e) {
-              console.warn('Profile image prefetch failed', e);
-            } finally {
-              finishLoading(imgKey);
-            }
+        if (uri && !_prefetched.current.has(uri)) {
+          const imgKey = 'profile-image';
+          startLoading(imgKey);
+          try {
+            await RNImage.prefetch(uri);
+            _prefetched.current.add(uri);
+          } catch (e) {
+            // eslint-disable-next-line no-console
+            console.debug('Profile image prefetch failed', e);
+          } finally {
+            finishLoading(imgKey);
           }
+        }
       } finally {
         if (mounted) setLoadingProfile(false);
         finishLoading(key);
       }
     })();
-    return () => { mounted = false; };
+    return () => {
+      mounted = false;
+    };
   }, [startLoading, finishLoading]);
 
   if (loadingProfile) {
     return (
-      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: colors.bg }}>
+      <View style={styles.loader}>
         <ActivityIndicator size="large" color={colors.primary} />
       </View>
     );
@@ -297,116 +334,206 @@ export default function UserProfile({ navigation, onLogout }: Readonly<UserProfi
 
   if (!profile) {
     return (
-      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: colors.bg }}>
+      <View style={styles.loader}>
         <Text style={{ color: colors.muted }}>{t('profile.noProfileData', 'No profile data available')}</Text>
       </View>
     );
   }
+
+  const quickActions: QuickAction[] = [
+    {
+      key: 'edit',
+      label: t('common.editProfile', 'Edit Profile'),
+      icon: 'create-outline',
+      onPress: openEdit,
+      tone: 'primary',
+    },
+    {
+      key: 'meds',
+      label: t('profile.myMedications', 'My Medications'),
+      icon: 'medkit-outline',
+      onPress: () => setMedicationsModal(true),
+      tone: 'primary',
+    },
+    {
+      key: 'privacy',
+      label: t('common.privacy', 'Privacy'),
+      icon: 'shield-checkmark-outline',
+      onPress: () => {},
+      tone: 'neutral',
+    },
+    {
+      key: 'logout',
+      label: t('auth.signOut', 'Logout'),
+      icon: 'log-out-outline',
+      onPress: handleLogout,
+      tone: 'danger',
+    },
+  ];
+
+  const renderActionButton = (action: QuickAction) => (
+    <Pressable
+      key={action.key}
+      onPress={action.onPress}
+      style={[
+        styles.quickButton,
+        action.tone === 'danger' && styles.quickButtonDanger,
+      ]}
+    >
+      <Ionicons
+        name={action.icon}
+        size={18}
+        color={action.tone === 'danger' ? '#FEE2E2' : '#F8FAFF'}
+      />
+      <Text style={styles.quickButtonText}>{action.label}</Text>
+    </Pressable>
+  );
+
   return (
-    <SafeAreaView style={{ flex: 1, backgroundColor: colors.bg }} edges={['top', 'left', 'right']}>
-      {/* Language Modal */}
-      <Modal visible={langModal} animationType="slide" transparent onRequestClose={() => setLangModal(false)}>
+    <>
+      <ScreenContainer
+        scrollable
+        contentContainerStyle={styles.content}
+        header={(
+          <LinearGradient
+            colors={colors.primaryGradient}
+            start={{ x: 0, y: 0 }}
+            end={{ x: 1, y: 1 }}
+            style={styles.hero}
+          >
+            <View style={styles.heroTop}>
+              <SkeletonImage
+                source={heroAvatar}
+                style={{ width: avatarSize, height: avatarSize, borderRadius: avatarSize / 2, backgroundColor: colors.line }}
+                resizeMode="cover"
+              />
+              <View style={{ flex: 1 }}>
+                <Text style={styles.heroName}>{profile.name}</Text>
+                <Text style={styles.heroMeta}>{profile.email}</Text>
+                {profile.phone ? <Text style={styles.heroMeta}>{profile.phone}</Text> : null}
+              </View>
+            </View>
+            <View style={styles.heroStats}>
+              <View style={styles.statPill}>
+                <Ionicons name="water-outline" size={16} color="#fff" />
+                <Text style={styles.statText}>{profile.blood_type || t('common.notSet', 'Not set')}</Text>
+              </View>
+              <View style={styles.statPill}>
+                <Ionicons name="flask-outline" size={16} color="#fff" />
+                <Text style={styles.statText}>{(profile.allergies || []).length} {t('auth.allergies', 'Allergies')}</Text>
+              </View>
+              <View style={styles.statPill}>
+                <Ionicons name="bandage-outline" size={16} color="#fff" />
+                <Text style={styles.statText}>{(profile.medical_conditions || []).length} {t('auth.medicalConditions', 'Conditions')}</Text>
+              </View>
+            </View>
+            <View style={styles.quickActions}>{quickActions.map(renderActionButton)}</View>
+          </LinearGradient>
+        )}
+      >
+        <Card style={styles.sectionCard}>
+          <Text style={styles.sectionTitle}>{t('profile.healthSummary', 'Health summary')}</Text>
+          <Text style={styles.sectionHint}>{t('profile.healthSummaryHint', 'Review and keep your medical data up to date.')}</Text>
+          <ListRow
+            title={t('profile.medicalId', 'Medical ID')}
+            subtitle={profile.blood_type ? `${t('auth.bloodType', 'Blood Type')}: ${profile.blood_type}` : undefined}
+            right={<Ionicons name="chevron-forward" size={18} color={colors.muted} />}
+            onPress={() => setMedicalModal(true)}
+          />
+          <View style={styles.listSpacer} />
+          <ListRow
+            title={t('profile.insurance', 'Insurance')}
+            subtitle={profile.insurance_info?.provider ? t('profile.providerWithValue', { provider: profile.insurance_info.provider }) : undefined}
+            right={<Ionicons name="chevron-forward" size={18} color={colors.muted} />}
+            onPress={() => setInsuranceModal(true)}
+          />
+          <View style={styles.listSpacer} />
+          <ListRow
+            title={t('profile.emergencyContacts', 'Emergency Contacts')}
+            subtitle={profile.emergency_contacts && profile.emergency_contacts.length > 0 ? profile.emergency_contacts[0].name : t('common.none', 'None')}
+            right={<Ionicons name="chevron-forward" size={18} color={colors.muted} />}
+            onPress={() => setEmergencyModal(true)}
+          />
+        </Card>
+
+        <Card style={styles.sectionCard}>
+          <Text style={styles.sectionTitle}>{t('profile.preferences', 'Preferences')}</Text>
+          <Pressable
+            onPress={() => setLangModal(true)}
+            style={styles.actionRow}
+          >
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: spacing.sm }}>
+              <View style={styles.actionIcon}>
+                <Ionicons name="language-outline" size={18} color={colors.primary} />
+              </View>
+              <View>
+                <Text style={styles.actionLabel}>{t('common.language', 'Language')}</Text>
+                <Text style={{ color: colors.muted }}>{currentLang.label}</Text>
+              </View>
+            </View>
+            <Ionicons name="chevron-forward" size={18} color={colors.muted} />
+          </Pressable>
+        </Card>
+
+        <Text style={styles.version}>v{pkg.version}</Text>
+      </ScreenContainer>
+
+      <Modal visible={langModal} animationType="fade" transparent onRequestClose={() => setLangModal(false)}>
         <View style={modalStyles.overlay}>
-          <View style={modalStyles.content}>
-            <Text style={{ fontWeight: 'bold', fontSize: 18, marginBottom: spacing.md }}>{t('common.languageSettings', 'Language Settings')}</Text>
+          <Card style={styles.modalCard}>
+            <Text style={{ ...type.h2, textAlign: 'center' }}>{t('common.languageSettings', 'Language Settings')}</Text>
             {languages.map(lang => (
               <Pressable
                 key={lang.code}
                 onPress={async () => {
                   await i18n.changeLanguage(lang.code);
                   setLangModal(false);
-                  setLangRefresh(r => r + 1); // force re-render
                 }}
-                style={{ flexDirection: 'row', alignItems: 'center', paddingVertical: 10, paddingHorizontal: 8, borderRadius: 8, backgroundColor: i18n.language === lang.code ? '#F3F4F6' : 'transparent', marginBottom: 4 }}
+                style={styles.modalLangRow}
               >
-                <RNImage source={lang.flag} style={{ width: 28, height: 20, borderRadius: 4, marginRight: 10 }} resizeMode="contain" />
-                <Text style={{ color: i18n.language === lang.code ? colors.primary : '#222', fontWeight: i18n.language === lang.code ? 'bold' : 'normal', fontSize: 16 }}>{lang.label}</Text>
+                <View style={{ flexDirection: 'row', alignItems: 'center', gap: spacing.sm }}>
+                  <RNImage source={lang.flag} style={{ width: 32, height: 20, borderRadius: 4 }} resizeMode="contain" />
+                  <Text style={{ color: colors.text, fontWeight: '600' }}>{lang.label}</Text>
+                </View>
+                {i18n.language === lang.code ? <Ionicons name="checkmark-circle" size={20} color={colors.primary} /> : null}
               </Pressable>
             ))}
-            <Pressable style={[modalStyles.btn, { backgroundColor: colors.primary, marginTop: spacing.lg }]} onPress={() => setLangModal(false)}>
-              <Text style={{ color: colors.card, fontWeight: 'bold', textAlign: 'center' }}>{t('common.close', 'Close')}</Text>
-            </Pressable>
-          </View>
+            <View style={styles.modalButtons}>
+              <Pressable style={styles.modalClose} onPress={() => setLangModal(false)}>
+                <Text style={styles.modalCloseText}>{t('common.close', 'Close')}</Text>
+              </Pressable>
+              <Pressable style={styles.modalConfirm} onPress={() => setLangModal(false)}>
+                <Text style={styles.modalConfirmText}>{t('common.save', 'Save')}</Text>
+              </Pressable>
+            </View>
+          </Card>
         </View>
       </Modal>
-  <ScrollView key={langRefresh} style={{ flex: 1, backgroundColor: colors.bg }} contentContainerStyle={{ padding: contentPadding, paddingBottom: Platform.OS === 'ios' ? 32 : 16 }}>
-        <Card style={styles.headerCard}>
-          <SkeletonImage source={require('../assets/avatar-placeholder.png')} style={[styles.avatar, { width: avatarSize, height: avatarSize, borderRadius: avatarSize / 2 }]} resizeMode="contain" />
-          <Text style={[type.h2, { marginTop: spacing.sm }]}>{profile.name}</Text>
-          <Text style={{ color: colors.muted }}>{profile.email}</Text>
-          <Text style={{ color: colors.muted }}>{profile.phone}</Text>
-        </Card>
-        <Card>
-          <ListRow
-            title={t('profile.medicalId', 'Medical ID')}
-            right={<Ionicons name="chevron-forward" size={20} color={colors.muted} />}
-            subtitle={profile.blood_type ? `${t('auth.bloodType', 'Blood Type')}: ${profile.blood_type}` : undefined}
-            onPress={() => setMedicalModal(true)}
-          />
-        </Card>
-        <Card>
-          <ListRow
-            title={t('profile.insurance', 'Insurance')}
-            right={<Ionicons name="chevron-forward" size={20} color={colors.muted} />}
-            subtitle={profile.insurance_info?.provider ? t('profile.providerWithValue', { provider: profile.insurance_info.provider }) : undefined}
-            onPress={() => setInsuranceModal(true)}
-          />
-        </Card>
-        <Card>
-          <ListRow
-            title={t('profile.emergencyContacts', 'Emergency Contacts')}
-            right={<Ionicons name="chevron-forward" size={20} color={colors.muted} />}
-            subtitle={profile.emergency_contacts && profile.emergency_contacts.length > 0 ? profile.emergency_contacts[0].name : undefined}
-            onPress={() => setEmergencyModal(true)}
-          />
-        </Card>
-        <View style={[styles.buttonGrid, { marginTop: spacing.lg, marginBottom: spacing.lg }]}>
-          <Pressable onPress={openEdit} style={({ pressed }) => [styles.buttonGridItem, styles.primaryButton, pressed && styles.buttonPressed]} android_ripple={{ color: colors.line }}>
-            <Text style={styles.btnTxt}>{t('common.editProfile', 'Edit Profile')}</Text>
-          </Pressable>
-          <Pressable onPress={() => setMedicationsModal(true)} style={({ pressed }) => [styles.buttonGridItem, styles.primaryButton, pressed && styles.buttonPressed]} android_ripple={{ color: colors.line }}>
-            <Text style={styles.btnTxt}>My Medications</Text>
-          </Pressable>
-          <Pressable style={({ pressed }) => [styles.buttonGridItem, styles.primaryButton, pressed && styles.buttonPressed]} android_ripple={{ color: colors.line }}>
-            <Text style={styles.btnTxt}>{t('common.privacy', 'Privacy')}</Text>
-          </Pressable>
-          <Pressable onPress={handleLogout} style={({ pressed }) => [styles.buttonGridItem, styles.signOutButton, pressed && styles.buttonPressed]} android_ripple={{ color: colors.primary600 }}>
-            <Text style={styles.btnTxt}>{t('auth.signOut', 'Logout')}</Text>
-          </Pressable>
-        </View>
-  <MedicationsSheet visible={medicationsModal} onClose={() => setMedicationsModal(false)} />
-        {/* Language Switcher as ListRow (below Emergency Contacts) */}
-        <Card>
-          <ListRow
-            title={t('common.language', 'Language')}
-            right={<RNImage source={currentLang.flag} style={{ width: 28, height: 20, borderRadius: 4 }} resizeMode="contain" />}
-            subtitle={currentLang.label}
-            onPress={() => setLangModal(true)}
-          />
-        </Card>
-        {/* Version Number */}
-        <View style={{ alignItems: 'center', marginTop: 16, marginBottom: 8 }}>
-          <Text style={{ color: colors.muted, fontSize: 13 }}>v{pkg.version}</Text>
-        </View>
-      </ScrollView>
-  <MedicalSheet visible={medicalModal} profile={profile} onClose={() => setMedicalModal(false)} />
-  <InsuranceSheet visible={insuranceModal} profile={profile} onClose={() => setInsuranceModal(false)} />
-  <EmergencySheet visible={emergencyModal} profile={profile} onClose={() => setEmergencyModal(false)} />
-      <EditProfileSheet visible={editModal} initial={edit} onSave={async (data) => {
-        setSaving(true);
-        try {
-          const userId = profile?.id || auth.currentUser?.uid;
-          if (!userId) throw new Error(t('errors.userIdMissing', 'User ID missing.'));
-          await createOrUpdateUserProfile({ ...data, id: userId });
-          const userProfile = await fetchUserProfile();
-          setProfile(userProfile);
-          setEditModal(false);
-        } catch (e: any) {
-          Alert.alert(t('common.error', 'Error'), e.message || t('errors.saveError', 'Failed to save profile.'));
-        } finally {
-          setSaving(false);
-        }
-      }} onClose={() => setEditModal(false)} />
-  </SafeAreaView>
+
+      <MedicationsSheet visible={medicationsModal} onClose={() => setMedicationsModal(false)} />
+      <MedicalSheet visible={medicalModal} profile={profile} onClose={() => setMedicalModal(false)} />
+      <InsuranceSheet visible={insuranceModal} profile={profile} onClose={() => setInsuranceModal(false)} />
+      <EmergencySheet visible={emergencyModal} profile={profile} onClose={() => setEmergencyModal(false)} />
+      <EditProfileSheet
+        visible={editModal}
+        initial={edit}
+        onSave={async data => {
+          setSaving(true);
+          try {
+            const userId = profile?.id || auth.currentUser?.uid;
+            if (!userId) throw new Error(t('errors.userIdMissing', 'User ID missing.'));
+            await createOrUpdateUserProfile({ ...data, id: userId });
+            const userProfile = await fetchUserProfile();
+            setProfile(userProfile);
+            setEditModal(false);
+          } catch (e: any) {
+            Alert.alert(t('common.error', 'Error'), e.message || t('errors.saveError', 'Failed to save profile.'));
+          } finally {
+            setSaving(false);
+          }
+        }}
+        onClose={() => setEditModal(false)}
+      />
+    </>
   );
 }

--- a/src/screens/user-sheets/EditProfileSheet.tsx
+++ b/src/screens/user-sheets/EditProfileSheet.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Modal, View, Text, Animated, Pressable, ScrollView, TextInput, Platform } from 'react-native';
+import { Modal, View, Text, Animated, Pressable, ScrollView, TextInput, Platform, StyleSheet } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import { Picker } from '@react-native-picker/picker';
+import { LinearGradient } from 'expo-linear-gradient';
 import { colors, spacing, radius } from '../../theme';
 
 type Props = {
@@ -11,6 +12,109 @@ type Props = {
   onSave: (data: any) => Promise<void>;
   initial: any;
 };
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(15,23,42,0.4)',
+    justifyContent: 'flex-end',
+  },
+  sheet: {
+    borderTopLeftRadius: radius.xl,
+    borderTopRightRadius: radius.xl,
+    overflow: 'hidden',
+  },
+  gradient: {
+    paddingHorizontal: spacing.xl,
+    paddingTop: spacing.xl,
+  },
+  handle: {
+    width: 48,
+    height: 5,
+    borderRadius: radius.pill,
+    backgroundColor: 'rgba(255,255,255,0.6)',
+    alignSelf: 'center',
+    marginBottom: spacing.lg,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: spacing.lg,
+  },
+  headerTitle: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: colors.text,
+  },
+  cancel: {
+    color: colors.muted,
+    fontWeight: '600',
+  },
+  saveButton: {
+    backgroundColor: colors.primary,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.sm,
+    borderRadius: radius.md,
+  },
+  saveText: {
+    color: colors.card,
+    fontWeight: '700',
+  },
+  scrollContent: {
+    paddingBottom: spacing.xxl,
+    gap: spacing.md,
+  },
+  label: {
+    fontWeight: '600',
+    color: colors.text,
+  },
+  input: {
+    backgroundColor: 'rgba(255,255,255,0.92)',
+    borderRadius: radius.md,
+    borderWidth: 1,
+    borderColor: 'rgba(37,99,235,0.15)',
+    paddingHorizontal: spacing.lg,
+    paddingVertical: 12,
+    fontSize: 16,
+    color: colors.text,
+  },
+  pickerWrap: {
+    borderWidth: 1,
+    borderColor: 'rgba(37,99,235,0.15)',
+    borderRadius: radius.md,
+    overflow: 'hidden',
+    backgroundColor: 'rgba(255,255,255,0.92)',
+  },
+  actionRow: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+    marginTop: spacing.lg,
+  },
+  secondaryBtn: {
+    flex: 1,
+    borderRadius: radius.md,
+    borderWidth: 1,
+    borderColor: colors.line,
+    paddingVertical: spacing.md,
+    alignItems: 'center',
+  },
+  secondaryText: {
+    color: colors.muted,
+    fontWeight: '600',
+  },
+  primaryBtn: {
+    flex: 1,
+    borderRadius: radius.md,
+    backgroundColor: colors.primary,
+    paddingVertical: spacing.md,
+    alignItems: 'center',
+  },
+  primaryText: {
+    color: colors.card,
+    fontWeight: '700',
+  },
+});
 
 export default function EditProfileSheet({ visible, onClose, onSave, initial }: Readonly<Props>) {
   const { t } = useTranslation();
@@ -22,7 +126,6 @@ export default function EditProfileSheet({ visible, onClose, onSave, initial }: 
   useEffect(() => {
     if (visible) {
       anim.setValue(0);
-      // avoid useNativeDriver on web / when native driver is not available to prevent console warnings
       Animated.timing(anim, { toValue: 1, duration: 360, useNativeDriver: Platform.OS !== 'web' }).start();
       setEdit(initial || {});
     }
@@ -32,43 +135,79 @@ export default function EditProfileSheet({ visible, onClose, onSave, initial }: 
 
   return (
     <Modal visible={visible} transparent animationType="none" onRequestClose={onClose}>
-      <View style={{ flex: 1, backgroundColor: colors.overlay, justifyContent: 'flex-end' }}>
-        <Animated.View style={{ backgroundColor: colors.card, borderTopLeftRadius: radius.md, borderTopRightRadius: radius.md, width: '100%', maxHeight: '90%', transform: [{ translateY }], overflow: 'hidden', paddingBottom: insets.bottom ?? 0 }}>
-          <View style={{ padding: 0 }}>
-            <View style={{ flexDirection: 'row', justifyContent: 'flex-end', alignItems: 'center', padding: 16, borderBottomWidth: 1, borderColor: colors.line, backgroundColor: colors.card, borderTopLeftRadius: radius.md, borderTopRightRadius: radius.md }}>
-              <Pressable onPress={onClose} style={{ marginRight: 12 }}>
-                <Text style={{ color: colors.muted, fontWeight: 'bold', fontSize: 16 }}>{t('common.cancel', 'Cancel')}</Text>
+      <View style={styles.overlay}>
+        <Animated.View
+          style={[
+            styles.sheet,
+            {
+              transform: [{ translateY }],
+            },
+          ]}
+        >
+          <LinearGradient
+            colors={colors.subtleGradient}
+            start={{ x: 0, y: 0 }}
+            end={{ x: 1, y: 1 }}
+            style={[styles.gradient, { paddingBottom: (insets.bottom ?? 0) + spacing.xxl }]}
+          >
+            <View style={styles.handle} />
+            <View style={styles.headerRow}>
+              <Pressable onPress={onClose} hitSlop={10}>
+                <Text style={styles.cancel}>{t('common.cancel', 'Cancel')}</Text>
               </Pressable>
-              <Pressable onPress={async () => { setSaving(true); await onSave(edit); setSaving(false); }} disabled={saving} style={{ backgroundColor: colors.primary, borderRadius: 8, paddingVertical: 8, paddingHorizontal: 18 }}>
-                <Text style={{ color: colors.card, fontWeight: 'bold', fontSize: 16 }}>{saving ? t('common.saving', 'Saving...') : t('common.save', 'Save')}</Text>
+              <Text style={styles.headerTitle}>{t('common.editProfile', 'Edit Profile')}</Text>
+              <Pressable
+                onPress={async () => {
+                  setSaving(true);
+                  await onSave(edit);
+                  setSaving(false);
+                }}
+                disabled={saving}
+                style={[styles.saveButton, saving && { opacity: 0.7 }]}
+              >
+                <Text style={styles.saveText}>{saving ? t('common.saving', 'Saving...') : t('common.save', 'Save')}</Text>
               </Pressable>
             </View>
-            <ScrollView style={{ flex: 1 }} contentContainerStyle={{ padding: 24, minWidth: 320, paddingBottom: (insets.bottom ?? 0) + 32 }} showsVerticalScrollIndicator={true}>
-              <Text style={{ fontWeight: 'bold', fontSize: 20, marginBottom: spacing.md }}>{t('common.editProfile', 'Edit Profile')}</Text>
-              <Text style={{ fontWeight: '600' }}>{t('profile.fullName', 'Full name')}</Text>
-              <TextInput value={edit.name} onChangeText={(v) => setEdit((e: any) => ({ ...e, name: v }))} style={{ borderWidth: 1, borderColor: colors.line, borderRadius: 8, padding: 12, marginBottom: 12 }} />
-
-              <Text style={{ fontWeight: '600' }}>{t('auth.phone', 'Phone')}</Text>
-              <TextInput value={edit.phone} onChangeText={(v) => setEdit((e: any) => ({ ...e, phone: v }))} style={{ borderWidth: 1, borderColor: colors.line, borderRadius: 8, padding: 12, marginBottom: 12 }} keyboardType="phone-pad" />
-
-              <Text style={{ fontWeight: '600' }}>{t('auth.bloodType', 'Blood Type')}</Text>
-              <View style={{ borderWidth: 1, borderColor: colors.line, borderRadius: 8, overflow: 'hidden', marginBottom: 8 }}>
-                <Picker selectedValue={edit.blood_type} onValueChange={(v) => setEdit((e: any) => ({ ...e, blood_type: v }))}>
-                  <Picker.Item label={t('common.notSet', 'Not set')} value={''} />
-                  <Picker.Item label="A+" value="A+" />
-                  <Picker.Item label="A-" value="A-" />
-                  <Picker.Item label="B+" value="B+" />
-                  <Picker.Item label="B-" value="B-" />
-                  <Picker.Item label="AB+" value="AB+" />
-                  <Picker.Item label="AB-" value="AB-" />
-                  <Picker.Item label="O+" value="O+" />
-                  <Picker.Item label="O-" value="O-" />
-                </Picker>
+            <ScrollView
+              style={{ flex: 1 }}
+              contentContainerStyle={styles.scrollContent}
+              showsVerticalScrollIndicator={false}
+            >
+              <View>
+                <Text style={styles.label}>{t('profile.fullName', 'Full name')}</Text>
+                <TextInput
+                  value={edit.name}
+                  onChangeText={v => setEdit((e: any) => ({ ...e, name: v }))}
+                  style={styles.input}
+                />
               </View>
-
-              {/* For brevity we keep only a compact set of edit fields here; other fields remain editable in the main app sheet */}
+              <View>
+                <Text style={styles.label}>{t('auth.phone', 'Phone')}</Text>
+                <TextInput
+                  value={edit.phone}
+                  onChangeText={v => setEdit((e: any) => ({ ...e, phone: v }))}
+                  style={styles.input}
+                  keyboardType="phone-pad"
+                />
+              </View>
+              <View>
+                <Text style={styles.label}>{t('auth.bloodType', 'Blood Type')}</Text>
+                <View style={styles.pickerWrap}>
+                  <Picker selectedValue={edit.blood_type} onValueChange={v => setEdit((e: any) => ({ ...e, blood_type: v }))}>
+                    <Picker.Item label={t('common.notSet', 'Not set')} value={''} />
+                    <Picker.Item label="A+" value="A+" />
+                    <Picker.Item label="A-" value="A-" />
+                    <Picker.Item label="B+" value="B+" />
+                    <Picker.Item label="B-" value="B-" />
+                    <Picker.Item label="AB+" value="AB+" />
+                    <Picker.Item label="AB-" value="AB-" />
+                    <Picker.Item label="O+" value="O+" />
+                    <Picker.Item label="O-" value="O-" />
+                  </Picker>
+                </View>
+              </View>
             </ScrollView>
-          </View>
+          </LinearGradient>
         </Animated.View>
       </View>
     </Modal>

--- a/src/screens/user-sheets/EmergencySheet.tsx
+++ b/src/screens/user-sheets/EmergencySheet.tsx
@@ -1,13 +1,82 @@
 import React, { useEffect, useRef } from 'react';
-import { Modal, View, Text, Animated, Pressable } from 'react-native';
+import { Modal, View, Text, Animated, Pressable, StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
-import { colors, spacing } from '../../theme';
+import { LinearGradient } from 'expo-linear-gradient';
+import { colors, spacing, radius } from '../../theme';
 
 type Props = {
   visible: boolean;
   onClose: () => void;
   profile: any;
 };
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(15,23,42,0.35)',
+    justifyContent: 'flex-end',
+  },
+  sheet: {
+    borderTopLeftRadius: radius.xl,
+    borderTopRightRadius: radius.xl,
+    overflow: 'hidden',
+  },
+  gradient: {
+    paddingHorizontal: spacing.xl,
+    paddingTop: spacing.xl,
+    paddingBottom: spacing.xxl,
+    gap: spacing.md,
+  },
+  handle: {
+    width: 48,
+    height: 5,
+    borderRadius: radius.pill,
+    backgroundColor: 'rgba(255,255,255,0.6)',
+    alignSelf: 'center',
+    marginBottom: spacing.lg,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: colors.text,
+  },
+  contactCard: {
+    backgroundColor: 'rgba(255,255,255,0.6)',
+    borderRadius: radius.lg,
+    padding: spacing.md,
+    gap: 4,
+  },
+  contactName: {
+    fontWeight: '700',
+    color: colors.text,
+  },
+  contactMeta: {
+    color: colors.muted,
+  },
+  badge: {
+    marginTop: 4,
+    alignSelf: 'flex-start',
+    backgroundColor: 'rgba(37,99,235,0.12)',
+    borderRadius: radius.pill,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.xs,
+  },
+  badgeText: {
+    color: colors.primary,
+    fontWeight: '600',
+  },
+  close: {
+    marginTop: spacing.xl,
+    backgroundColor: colors.primary,
+    borderRadius: radius.md,
+    paddingVertical: spacing.md,
+    alignItems: 'center',
+  },
+  closeText: {
+    color: colors.card,
+    fontWeight: '700',
+  },
+});
 
 export default function EmergencySheet({ visible, onClose, profile }: Readonly<Props>) {
   const { t } = useTranslation();
@@ -24,20 +93,33 @@ export default function EmergencySheet({ visible, onClose, profile }: Readonly<P
 
   return (
     <Modal visible={visible} transparent animationType="none" onRequestClose={onClose}>
-      <View style={{ flex: 1, backgroundColor: colors.overlay, justifyContent: 'flex-end' }}>
-        <Animated.View style={{ backgroundColor: colors.card, borderTopLeftRadius: 16, borderTopRightRadius: 16, padding: 24, width: '100%', maxHeight: '80%', transform: [{ translateY }] }}>
-          <Text style={{ fontWeight: 'bold', fontSize: 18, marginBottom: spacing.md }}>{t('profile.emergencyContacts', 'Emergency Contacts')}</Text>
-          {profile?.emergency_contacts && profile.emergency_contacts.length > 0 ? profile.emergency_contacts.map((c: any, i: number) => (
-            <View key={c.id || i} style={{ marginBottom: 10 }}>
-              <Text style={{ color: colors.text, fontWeight: '600' }}>{c.name}</Text>
-              <Text style={{ color: colors.muted }}>{c.relationship}</Text>
-              <Text style={{ color: colors.muted }}>{c.phone}</Text>
-              {c.isICE && <Text style={{ color: colors.primary, fontWeight: '600' }}>{t('profile.ice', 'ICE')}</Text>}
-            </View>
-          )) : <Text style={{ color: colors.muted }}>{t('profile.noEmergencyContacts', 'No emergency contacts')}</Text>}
-          <Pressable style={{ paddingVertical: 12, borderRadius: 8, alignItems: 'center', justifyContent: 'center', backgroundColor: colors.primary, marginTop: spacing.lg }} onPress={() => { Animated.timing(anim, { toValue: 0, duration: 180, useNativeDriver: true }).start(onClose); }}>
-            <Text style={{ color: colors.card, fontWeight: 'bold', textAlign: 'center' }}>{t('common.close', 'Close')}</Text>
-          </Pressable>
+      <View style={styles.overlay}>
+        <Animated.View style={[styles.sheet, { transform: [{ translateY }] }] }>
+          <LinearGradient colors={colors.subtleGradient} start={{ x: 0, y: 0 }} end={{ x: 1, y: 1 }} style={styles.gradient}>
+            <View style={styles.handle} />
+            <Text style={styles.title}>{t('profile.emergencyContacts', 'Emergency Contacts')}</Text>
+            {profile?.emergency_contacts && profile.emergency_contacts.length > 0 ? (
+              profile.emergency_contacts.map((c: any, i: number) => (
+                <View key={c.id || i} style={styles.contactCard}>
+                  <Text style={styles.contactName}>{c.name}</Text>
+                  <Text style={styles.contactMeta}>{c.relationship}</Text>
+                  <Text style={styles.contactMeta}>{c.phone}</Text>
+                  {c.isICE ? (
+                    <View style={styles.badge}>
+                      <Text style={styles.badgeText}>{t('profile.ice', 'ICE')}</Text>
+                    </View>
+                  ) : null}
+                </View>
+              ))
+            ) : (
+              <Text style={styles.contactMeta}>{t('profile.noEmergencyContacts', 'No emergency contacts')}</Text>
+            )}
+            <Pressable style={styles.close} onPress={() => {
+              Animated.timing(anim, { toValue: 0, duration: 180, useNativeDriver: true }).start(onClose);
+            }}>
+              <Text style={styles.closeText}>{t('common.close', 'Close')}</Text>
+            </Pressable>
+          </LinearGradient>
         </Animated.View>
       </View>
     </Modal>

--- a/src/screens/user-sheets/InsuranceSheet.tsx
+++ b/src/screens/user-sheets/InsuranceSheet.tsx
@@ -1,13 +1,68 @@
 import React, { useEffect, useRef } from 'react';
-import { Modal, View, Text, Animated, Pressable } from 'react-native';
+import { Modal, View, Text, Animated, Pressable, StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
-import { colors, spacing } from '../../theme';
+import { LinearGradient } from 'expo-linear-gradient';
+import { colors, spacing, radius } from '../../theme';
 
 type Props = {
   visible: boolean;
   onClose: () => void;
   profile: any;
 };
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(15,23,42,0.35)',
+    justifyContent: 'flex-end',
+  },
+  sheet: {
+    borderTopLeftRadius: radius.xl,
+    borderTopRightRadius: radius.xl,
+    overflow: 'hidden',
+  },
+  gradient: {
+    paddingHorizontal: spacing.xl,
+    paddingTop: spacing.xl,
+    paddingBottom: spacing.xxl,
+    gap: spacing.md,
+  },
+  handle: {
+    width: 48,
+    height: 5,
+    borderRadius: radius.pill,
+    backgroundColor: 'rgba(255,255,255,0.6)',
+    alignSelf: 'center',
+    marginBottom: spacing.lg,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: colors.text,
+  },
+  description: {
+    color: colors.muted,
+  },
+  item: {
+    color: colors.text,
+    fontWeight: '600',
+  },
+  value: {
+    color: colors.muted,
+    marginLeft: spacing.sm,
+  },
+  close: {
+    marginTop: spacing.xl,
+    backgroundColor: colors.primary,
+    borderRadius: radius.md,
+    paddingVertical: spacing.md,
+    alignItems: 'center',
+  },
+  closeText: {
+    color: colors.card,
+    fontWeight: '700',
+  },
+});
 
 export default function InsuranceSheet({ visible, onClose, profile }: Readonly<Props>) {
   const { t } = useTranslation();
@@ -24,18 +79,31 @@ export default function InsuranceSheet({ visible, onClose, profile }: Readonly<P
 
   return (
     <Modal visible={visible} transparent animationType="none" onRequestClose={onClose}>
-      <View style={{ flex: 1, backgroundColor: colors.overlay, justifyContent: 'flex-end' }}>
-        <Animated.View style={{ backgroundColor: colors.card, borderTopLeftRadius: 16, borderTopRightRadius: 16, padding: 24, width: '100%', maxHeight: '80%', transform: [{ translateY }] }}>
-          <Text style={{ fontWeight: 'bold', fontSize: 18, marginBottom: spacing.md }}>{t('profile.insurance', 'Insurance')}</Text>
-          {profile?.insurance_info ? (
-            <>
-              <Text style={{ color: colors.text, fontWeight: '600', marginBottom: 6 }}>{t('profile.provider', 'Provider')}: <Text style={{ color: colors.muted }}>{profile.insurance_info.provider || t('common.notSet', 'Not set')}</Text></Text>
-              <Text style={{ color: colors.text, fontWeight: '600', marginBottom: 6 }}>{t('profile.policyNumber', 'Policy #')}: <Text style={{ color: colors.muted }}>{profile.insurance_info.policy_number || t('common.notSet', 'Not set')}</Text></Text>
-            </>
-          ) : <Text style={{ color: colors.muted }}>{t('profile.noInsuranceInfo', 'No insurance info.')}</Text>}
-          <Pressable style={{ paddingVertical: 12, borderRadius: 8, alignItems: 'center', justifyContent: 'center', backgroundColor: colors.primary, marginTop: spacing.lg }} onPress={() => { Animated.timing(anim, { toValue: 0, duration: 180, useNativeDriver: true }).start(onClose); }}>
-            <Text style={{ color: colors.card, fontWeight: 'bold', textAlign: 'center' }}>{t('common.close', 'Close')}</Text>
-          </Pressable>
+      <View style={styles.overlay}>
+        <Animated.View style={[styles.sheet, { transform: [{ translateY }] }] }>
+          <LinearGradient colors={colors.subtleGradient} start={{ x: 0, y: 0 }} end={{ x: 1, y: 1 }} style={styles.gradient}>
+            <View style={styles.handle} />
+            <Text style={styles.title}>{t('profile.insurance', 'Insurance')}</Text>
+            {profile?.insurance_info ? (
+              <>
+                <Text style={styles.item}>
+                  {t('profile.provider', 'Provider')}
+                  <Text style={styles.value}> {profile.insurance_info.provider || t('common.notSet', 'Not set')}</Text>
+                </Text>
+                <Text style={styles.item}>
+                  {t('profile.policyNumber', 'Policy #')}
+                  <Text style={styles.value}> {profile.insurance_info.policy_number || t('common.notSet', 'Not set')}</Text>
+                </Text>
+              </>
+            ) : (
+              <Text style={styles.description}>{t('profile.noInsuranceInfo', 'No insurance info.')}</Text>
+            )}
+            <Pressable style={styles.close} onPress={() => {
+              Animated.timing(anim, { toValue: 0, duration: 180, useNativeDriver: true }).start(onClose);
+            }}>
+              <Text style={styles.closeText}>{t('common.close', 'Close')}</Text>
+            </Pressable>
+          </LinearGradient>
         </Animated.View>
       </View>
     </Modal>

--- a/src/screens/user-sheets/MedicalSheet.tsx
+++ b/src/screens/user-sheets/MedicalSheet.tsx
@@ -1,13 +1,72 @@
 import React, { useEffect, useRef } from 'react';
-import { Modal, View, Text, Animated, Pressable } from 'react-native';
+import { Modal, View, Text, Animated, Pressable, StyleSheet, ScrollView } from 'react-native';
 import { useTranslation } from 'react-i18next';
-import { colors, spacing } from '../../theme';
+import { LinearGradient } from 'expo-linear-gradient';
+import { colors, spacing, radius } from '../../theme';
 
 type Props = {
   visible: boolean;
   onClose: () => void;
   profile: any;
 };
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(15,23,42,0.35)',
+    justifyContent: 'flex-end',
+  },
+  sheet: {
+    borderTopLeftRadius: radius.xl,
+    borderTopRightRadius: radius.xl,
+    overflow: 'hidden',
+  },
+  gradient: {
+    paddingHorizontal: spacing.xl,
+    paddingTop: spacing.xl,
+    paddingBottom: spacing.xxl,
+  },
+  handle: {
+    width: 48,
+    height: 5,
+    borderRadius: radius.pill,
+    backgroundColor: 'rgba(255,255,255,0.6)',
+    alignSelf: 'center',
+    marginBottom: spacing.lg,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: colors.text,
+    marginBottom: spacing.sm,
+  },
+  sectionLabel: {
+    fontWeight: '600',
+    color: colors.text,
+    marginTop: spacing.md,
+    marginBottom: spacing.xs,
+  },
+  item: {
+    color: colors.muted,
+    marginLeft: spacing.sm,
+    marginBottom: 4,
+  },
+  closeButton: {
+    marginTop: spacing.xl,
+    backgroundColor: colors.primary,
+    borderRadius: radius.md,
+    paddingVertical: spacing.md,
+    alignItems: 'center',
+    shadowColor: colors.primary,
+    shadowOpacity: 0.15,
+    shadowRadius: 12,
+    shadowOffset: { width: 0, height: 6 },
+  },
+  closeText: {
+    color: colors.card,
+    fontWeight: '700',
+  },
+});
 
 export default function MedicalSheet({ visible, onClose, profile }: Readonly<Props>) {
   const { t } = useTranslation();
@@ -24,19 +83,42 @@ export default function MedicalSheet({ visible, onClose, profile }: Readonly<Pro
 
   return (
     <Modal visible={visible} transparent animationType="none" onRequestClose={onClose}>
-      <View style={{ flex: 1, backgroundColor: colors.overlay, justifyContent: 'flex-end' }}>
-        <Animated.View style={{ backgroundColor: colors.card, borderTopLeftRadius: 16, borderTopRightRadius: 16, padding: 24, width: '100%', maxHeight: '80%', transform: [{ translateY }] }}>
-          <Text style={{ fontWeight: 'bold', fontSize: 18, marginBottom: spacing.md }}>{t('profile.medicalId', 'Medical ID')}</Text>
-          <Text style={{ color: colors.text, fontWeight: '600', marginBottom: 6 }}>{t('auth.bloodType', 'Blood Type')}: <Text style={{ color: colors.muted }}>{profile?.blood_type || t('common.notSet', 'Not set')}</Text></Text>
-          <Text style={{ color: colors.text, fontWeight: '600', marginTop: 10, marginBottom: 6 }}>{t('auth.allergies', 'Allergies')}:</Text>
-          {profile?.allergies && profile.allergies.length > 0 ? profile.allergies.map((a: string) => <Text key={a} style={{ color: colors.muted, marginLeft: 8 }}>• {a}</Text>) : <Text style={{ color: colors.muted, marginLeft: 8 }}>{t('common.none', 'None')}</Text>}
-          <Text style={{ color: colors.text, fontWeight: '600', marginTop: 10, marginBottom: 6 }}>{t('auth.medicalConditions', 'Medical Conditions')}:</Text>
-          {profile?.medical_conditions && profile.medical_conditions.length > 0 ? profile.medical_conditions.map((c: string) => <Text key={c} style={{ color: colors.muted, marginLeft: 8 }}>• {c}</Text>) : <Text style={{ color: colors.muted, marginLeft: 8 }}>{t('common.none', 'None')}</Text>}
-          <Text style={{ color: colors.text, fontWeight: '600', marginTop: 10, marginBottom: 6 }}>{t('auth.medications', 'Medications')}:</Text>
-          {profile?.medications && profile.medications.length > 0 ? profile.medications.map((m: string) => <Text key={m} style={{ color: colors.muted, marginLeft: 8 }}>• {m}</Text>) : <Text style={{ color: colors.muted, marginLeft: 8 }}>{t('common.none', 'None')}</Text>}
-          <Pressable style={{ paddingVertical: 12, borderRadius: 8, alignItems: 'center', justifyContent: 'center', backgroundColor: colors.primary, marginTop: spacing.lg }} onPress={() => { Animated.timing(anim, { toValue: 0, duration: 180, useNativeDriver: true }).start(onClose); }}>
-            <Text style={{ color: colors.card, fontWeight: 'bold', textAlign: 'center' }}>{t('common.close', 'Close')}</Text>
-          </Pressable>
+      <View style={styles.overlay}>
+        <Animated.View style={[styles.sheet, { transform: [{ translateY }] }] }>
+          <LinearGradient colors={colors.subtleGradient} start={{ x: 0, y: 0 }} end={{ x: 1, y: 1 }} style={styles.gradient}>
+            <View style={styles.handle} />
+            <Text style={styles.title}>{t('profile.medicalId', 'Medical ID')}</Text>
+            <ScrollView showsVerticalScrollIndicator={false}>
+              <Text style={styles.sectionLabel}>{t('auth.bloodType', 'Blood Type')}</Text>
+              <Text style={styles.item}>{profile?.blood_type || t('common.notSet', 'Not set')}</Text>
+
+              <Text style={styles.sectionLabel}>{t('auth.allergies', 'Allergies')}</Text>
+              {profile?.allergies && profile.allergies.length > 0
+                ? profile.allergies.map((a: string) => (
+                    <Text key={a} style={styles.item}>• {a}</Text>
+                  ))
+                : <Text style={styles.item}>{t('common.none', 'None')}</Text>}
+
+              <Text style={styles.sectionLabel}>{t('auth.medicalConditions', 'Medical Conditions')}</Text>
+              {profile?.medical_conditions && profile.medical_conditions.length > 0
+                ? profile.medical_conditions.map((c: string) => (
+                    <Text key={c} style={styles.item}>• {c}</Text>
+                  ))
+                : <Text style={styles.item}>{t('common.none', 'None')}</Text>}
+
+              <Text style={styles.sectionLabel}>{t('auth.medications', 'Medications')}</Text>
+              {profile?.medications && profile.medications.length > 0
+                ? profile.medications.map((m: string) => (
+                    <Text key={m} style={styles.item}>• {m}</Text>
+                  ))
+                : <Text style={styles.item}>{t('common.none', 'None')}</Text>}
+            </ScrollView>
+            <Pressable style={styles.closeButton} onPress={() => {
+              Animated.timing(anim, { toValue: 0, duration: 180, useNativeDriver: true }).start(onClose);
+            }}>
+              <Text style={styles.closeText}>{t('common.close', 'Close')}</Text>
+            </Pressable>
+          </LinearGradient>
         </Animated.View>
       </View>
     </Modal>

--- a/src/screens/user-sheets/MedicationsSheet.tsx
+++ b/src/screens/user-sheets/MedicationsSheet.tsx
@@ -1,13 +1,62 @@
 import React, { useEffect, useRef } from 'react';
-import { Modal, View, Text, Animated, Pressable } from 'react-native';
+import { Modal, View, Text, Animated, Pressable, StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
-import { colors, radius } from '../../theme';
+import { LinearGradient } from 'expo-linear-gradient';
+import { colors, radius, spacing } from '../../theme';
 import MyMedicationsList from '../../components/MyMedicationsList';
 
 type Props = {
   visible: boolean;
   onClose: () => void;
 };
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(15,23,42,0.35)',
+    justifyContent: 'flex-end',
+  },
+  sheet: {
+    borderTopLeftRadius: radius.xl,
+    borderTopRightRadius: radius.xl,
+    overflow: 'hidden',
+    maxHeight: '88%',
+  },
+  gradient: {
+    paddingHorizontal: spacing.xl,
+    paddingTop: spacing.xl,
+    paddingBottom: spacing.xxl,
+    gap: spacing.lg,
+  },
+  handle: {
+    width: 48,
+    height: 5,
+    borderRadius: radius.pill,
+    backgroundColor: 'rgba(255,255,255,0.6)',
+    alignSelf: 'center',
+  },
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginTop: spacing.lg,
+  },
+  title: {
+    fontSize: 22,
+    fontWeight: '700',
+    color: colors.text,
+  },
+  close: {
+    color: colors.muted,
+    fontWeight: '600',
+  },
+  listWrap: {
+    flex: 1,
+    backgroundColor: 'rgba(255,255,255,0.55)',
+    borderRadius: radius.lg,
+    padding: spacing.md,
+  },
+});
 
 export default function MedicationsSheet({ visible, onClose }: Readonly<Props>) {
   const { t } = useTranslation();
@@ -24,15 +73,22 @@ export default function MedicationsSheet({ visible, onClose }: Readonly<Props>) 
 
   return (
     <Modal visible={visible} transparent animationType="none" onRequestClose={onClose}>
-      <View style={{ flex: 1, backgroundColor: colors.overlay, justifyContent: 'flex-end' }}>
-        <Animated.View style={{ backgroundColor: colors.card, borderTopLeftRadius: radius.xl, borderTopRightRadius: radius.xl, paddingTop: 32, paddingHorizontal: 20, minHeight: '50%', maxHeight: '90%', overflow: 'hidden', transform: [{ translateY }] }}>
-          <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 18 }}>
-            <Text style={{ fontWeight: 'bold', fontSize: 22, color: colors.text }}>{t('profile.myMedications', 'My Medications')}</Text>
-            <Pressable onPress={() => { Animated.timing(anim, { toValue: 0, duration: 180, useNativeDriver: true }).start(onClose); }} hitSlop={10}>
-              <Text style={{ color: colors.muted, fontWeight: '600', fontSize: 16 }}>{t('common.close', 'Close')}</Text>
-            </Pressable>
-          </View>
-          <MyMedicationsList />
+      <View style={styles.overlay}>
+        <Animated.View style={[styles.sheet, { transform: [{ translateY }] }]}>
+          <LinearGradient colors={colors.subtleGradient} start={{ x: 0, y: 0 }} end={{ x: 1, y: 1 }} style={styles.gradient}>
+            <View style={styles.handle} />
+            <View style={styles.headerRow}>
+              <Text style={styles.title}>{t('profile.myMedications', 'My Medications')}</Text>
+              <Pressable onPress={() => {
+                Animated.timing(anim, { toValue: 0, duration: 200, useNativeDriver: true }).start(onClose);
+              }} hitSlop={10}>
+                <Text style={styles.close}>{t('common.close', 'Close')}</Text>
+              </Pressable>
+            </View>
+            <View style={styles.listWrap}>
+              <MyMedicationsList />
+            </View>
+          </LinearGradient>
         </Animated.View>
       </View>
     </Modal>

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,27 +1,35 @@
 export const colors = {
   primary: '#2563EB',
-  primary700: '#1E40AF',
+  primary700: '#1E3A8A',
   // compatibility alias used across the codebase
-  primary600: '#1E40AF',
-  accent: '#22C55E',
+  primary600: '#1D4ED8',
+  accent: '#2DD4BF',
+  secondary: '#7C3AED',
   warn: '#F59E0B',
   danger: '#EF4444',
+  success: '#16A34A',
   // slightly cooler background for depth
-  bg: '#F3F6FF',
+  bg: '#F1F5FF',
   card: '#FFFFFF',
-  surface: '#FFFFFF',
+  surface: '#F8FBFF',
   text: '#0F172A',
   // a hair darker for contrast
-  muted: '#64748B',
+  muted: '#5B6B8C',
   // lighter lines
-  line: '#EDF0F7',
-  // stronger overlay for modals
-  overlay: 'rgba(15,23,42,0.10)',
+  line: '#E0E7FF',
+  // translucent overlays and accents
+  overlay: 'rgba(15,23,42,0.12)',
+  glass: 'rgba(255,255,255,0.72)',
   // new tokens for chips/progress
-  chipBg: '#F6F8FF',
-  chipText: '#334155',
-  progressTrack: '#E9EEFF',
-  progressFill: '#2563EB'
+  chipBg: '#EFF4FF',
+  chipText: '#1F2937',
+  progressTrack: '#E2E8FF',
+  progressFill: '#2563EB',
+  // gradients
+  primaryGradient: ['#2563EB', '#7C3AED'] as const,
+  accentGradient: ['#34D399', '#22D3EE'] as const,
+  cardGradient: ['rgba(37,99,235,0.12)', 'rgba(124,58,237,0.08)'] as const,
+  subtleGradient: ['rgba(255,255,255,0.86)', 'rgba(241,245,255,0.92)'] as const,
 };
 
 export const radius = { xs: 8, md: 12, lg: 16, xl: 22, pill: 999 };
@@ -32,8 +40,20 @@ export const radius = { xs: 8, md: 12, lg: 16, xl: 22, pill: 999 };
 export const spacing = { xs: 6, sm: 8, md: 12, lg: 16, xl: 22, xxl: 30 };
 
 export const shadow = {
-  card: { elevation: 5, shadowColor: '#0B132B', shadowOpacity: 0.08, shadowRadius: 12, shadowOffset: { width: 0, height: 7 } },
-  soft: { elevation: 3, shadowColor: '#0B132B', shadowOpacity: 0.05, shadowRadius: 8, shadowOffset: { width: 0, height: 4 } }
+  card: {
+    elevation: 6,
+    shadowColor: 'rgba(15,23,42,0.22)',
+    shadowOpacity: 0.22,
+    shadowRadius: 18,
+    shadowOffset: { width: 0, height: 12 },
+  },
+  soft: {
+    elevation: 3,
+    shadowColor: 'rgba(15,23,42,0.18)',
+    shadowOpacity: 0.18,
+    shadowRadius: 10,
+    shadowOffset: { width: 0, height: 6 },
+  },
 };
 
 export const type = {


### PR DESCRIPTION
## Summary
- refresh the login flow with a gradient hero, segmented auth toggle, and glassy modals built on ScreenContainer/Card
- restyle the user profile surface plus all supporting sheets with the new glassmorphism sheet pattern and quick-action tiles
- modernize the scanner, drug info, and native map surfaces with gradient headers, chip filters, and card-based layouts for results/history

## Testing
- npm test *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cdede5c600832b8a04771abaf5308b