### PR TITLE
Fix native map shim import

### DIFF
--- a/src/screens/ClinicsHospitalsPharmaciesMap.tsx
+++ b/src/screens/ClinicsHospitalsPharmaciesMap.tsx
@@ -1,3 +1,17 @@
-// This file intentionally left as a pass-through so imports can target
-// './ClinicsHospitalsPharmaciesMap' and Metro will pick .native or .web.
-export { default } from './ClinicsHospitalsPharmaciesMap.web';
+import { Platform } from 'react-native';
+
+// Metro will normally prefer the platform specific extension automatically, but
+// we still keep this shim so TypeScript consumers can import the module without
+// having to reach for the native/web filenames directly. The previous
+// implementation always re-exported the web bundle which caused the DOM-based
+// Leaflet map to load on native Hermes builds and crash before the app could
+// register.
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires, global-require
+const Impl = Platform.OS === 'web'
+  // eslint-disable-next-line @typescript-eslint/no-var-requires, import/no-dynamic-require
+  ? require('./ClinicsHospitalsPharmaciesMap.web').default
+  // eslint-disable-next-line @typescript-eslint/no-var-requires, import/no-dynamic-require
+  : require('./ClinicsHospitalsPharmaciesMap.native').default;
+
+export default Impl;


### PR DESCRIPTION
## Summary
- switch the ClinicsHospitalsPharmaciesMap shim to choose the native implementation on non-web platforms so Hermes no longer loads the Leaflet-based bundle
- keep the TypeScript-friendly indirection while dynamically requiring the correct file to avoid Metro resolution surprises

## Testing
- npm test *(fails: jest not found because dependencies are not installed)*
- npm install *(fails: peer dependency conflict between react-native@0.79.5 and @types/react@18)*

------
https://chatgpt.com/codex/tasks/task_e_68ce00351e44832ba1b7ac375d4c853d